### PR TITLE
Add named exports for exported object literals

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import { walk } from 'estree-walker';
 import MagicString from 'magic-string';
 import { attachScopes, createFilter, makeLegalIdentifier } from 'rollup-pluginutils';
 import { flatten, isReference } from './ast-utils.js';
+import { staticObject } from './node-test.js';
 
 var firstpass = /\b(?:require|module|exports|global)\b/;
 var exportsPattern = /^(?:module\.)?exports(?:\.([a-zA-Z_$][a-zA-Z_$0-9]*))?$/;
@@ -88,6 +89,12 @@ export default function commonjs ( options = {} ) {
 
 						const match = exportsPattern.exec( flattened.keypath );
 						if ( !match || flattened.keypath === 'exports' ) return;
+
+						if ( flattened.keypath === 'module.exports' && staticObject( node.right ) ) {
+							return node.right.properties.forEach( prop => {
+								namedExports[ prop.key.name ] = true;
+							});
+						}
 
 						if ( match[1] ) namedExports[ match[1] ] = true;
 

--- a/src/node-test.js
+++ b/src/node-test.js
@@ -1,0 +1,21 @@
+export function staticObject ( node ) {
+  return node.type === 'ObjectExpression' && node.properties.every( prop =>
+    !prop.computed && staticValue( prop.value ) );
+}
+
+export function staticMember ( node ) {
+  return node.type === 'MemberExpression' && literal( node.property ) &&
+    ( literal( node.object ) || staticMember( node.object ) );
+}
+
+export function staticValue ( node ) {
+  return literal( node ) || identifier( node ) || staticObject( node ) || staticMember( node );
+}
+
+export function literal ( node ) {
+  return node.type === 'Literal';
+}
+
+export function identifier ( node ) {
+  return node.type === 'Identifier';
+}

--- a/test/samples/named-exports-from-object-literal/a.js
+++ b/test/samples/named-exports-from-object-literal/a.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/test/samples/named-exports-from-object-literal/main.js
+++ b/test/samples/named-exports-from-object-literal/main.js
@@ -1,0 +1,4 @@
+import { a, b } from './other.js';
+
+assert.equal( a, 1 );
+assert.equal( b, 2 );

--- a/test/samples/named-exports-from-object-literal/other.js
+++ b/test/samples/named-exports-from-object-literal/other.js
@@ -1,0 +1,7 @@
+var a = require( './a.js' );
+var b = 2;
+
+module.exports = {
+  a: a,
+  b: b
+};

--- a/test/test.js
+++ b/test/test.js
@@ -172,6 +172,20 @@ describe( 'rollup-plugin-commonjs', function () {
 		});
 	});
 
+	it( 'identifies named exports from object literals', function () {
+		return rollup.rollup({
+			entry: 'samples/named-exports-from-object-literal/main.js',
+			plugins: [ commonjs() ]
+		}).then( function ( bundle ) {
+			var generated = bundle.generate({
+				format: 'cjs'
+			});
+
+			var fn = new Function ( 'module', 'assert', generated.code );
+			fn( {}, assert );
+		});
+	});
+
 	it( 'handles references to `global`', function () {
 		return rollup.rollup({
 			entry: 'samples/global/main.js',


### PR DESCRIPTION
If we can safely determine that a static object literal is assigned to `module.exports`, we can add named exports for its properties.

Fix #9 