### PR TITLE
Optimise module exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,7 @@ rollup({
     // specifically include/exclude files
     commonjs({
       include: 'node_modules/**',
-      exclude: [ 'node_modules/foo/**', 'node_modules/bar/**' ],
-      
-      // add this if you want to generate sourcemaps later
-      sourceMap: true
+      exclude: [ 'node_modules/foo/**', 'node_modules/bar/**' ]
     })
   ]
 }).then(...)

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import { walk } from 'estree-walker';
 import MagicString from 'magic-string';
 import { attachScopes, createFilter } from 'rollup-pluginutils';
 import { flatten, isReference } from './ast-utils.js';
+import { staticObject } from './node-test.js';
 
 var firstpass = /\b(?:require|module|exports|global)\b/;
 var exportsPattern = /^(?:module\.)?exports(?:\.([a-zA-Z_$][a-zA-Z_$0-9]*))?$/;
@@ -81,6 +82,12 @@ export default function commonjs ( options = {} ) {
 
 						const match = exportsPattern.exec( flattened.keypath );
 						if ( !match || flattened.keypath === 'exports' ) return;
+
+						if ( flattened.keypath === 'module.exports' && staticObject( node.right ) ) {
+							return node.right.properties.forEach( prop => {
+								namedExports[ prop.key.name ] = true;
+							});
+						}
 
 						if ( match[1] ) namedExports[ match[1] ] = true;
 

--- a/src/index.js
+++ b/src/index.js
@@ -56,10 +56,15 @@ export default function commonjs ( options = {} ) {
 			let required = {};
 			let uid = 0;
 
+			// Set `topLevel = true` on all top level statements
+			ast.body.forEach( node => node.topLevel = true );
+
 			let scope = attachScopes( ast, 'scope' );
 			let namedExports = {};
 			let usesModuleOrExports = false;
 			let usesGlobal = false;
+
+			let hasOptimisedModuleExports = false;
 
 			// identifier start-indicies to ignore when determining
 			// if the module `usesModuleOrExports` or `usesGlobal`
@@ -87,7 +92,8 @@ export default function commonjs ( options = {} ) {
 						const match = exportsPattern.exec( flattened.keypath );
 						if ( !match || flattened.keypath === 'exports' ) return;
 
-						if ( flattened.keypath === 'module.exports' ) {
+						if ( !hasOptimisedModuleExports && flattened.keypath === 'module.exports' && parent.topLevel ) {
+							hasOptimisedModuleExports = true;
 
 							// we can't optimise object expressions without a function wrapper yet
 							if ( node.right.type === 'ObjectExpression' ) {

--- a/src/node-test.js
+++ b/src/node-test.js
@@ -1,0 +1,21 @@
+export function staticObject ( node ) {
+  return node.type === 'ObjectExpression' && node.properties.every( prop =>
+    !prop.computed && staticValue( prop.value ) );
+}
+
+export function staticMember ( node ) {
+  return node.type === 'MemberExpression' && literal( node.property ) &&
+    ( literal( node.object ) || staticMember( node.object ) );
+}
+
+export function staticValue ( node ) {
+  return literal( node ) || identifier( node ) || staticObject( node ) || staticMember( node );
+}
+
+export function literal ( node ) {
+  return node.type === 'Literal';
+}
+
+export function identifier ( node ) {
+  return node.type === 'Identifier';
+}

--- a/test/samples/bare/main.js
+++ b/test/samples/bare/main.js
@@ -1,0 +1,1 @@
+require('./side-effects');

--- a/test/samples/cannot-optimise-module-exports-reassign/main.js
+++ b/test/samples/cannot-optimise-module-exports-reassign/main.js
@@ -1,0 +1,2 @@
+module.exports = 1;
+module.exports = 2;

--- a/test/samples/corejs/_html.js
+++ b/test/samples/corejs/_html.js
@@ -1,0 +1,1 @@
+module.exports = require('./_global').document && document.documentElement;

--- a/test/samples/corejs/_path.js
+++ b/test/samples/corejs/_path.js
@@ -1,0 +1,1 @@
+module.exports = require('./_global');

--- a/test/samples/corejs/_redefine.js
+++ b/test/samples/corejs/_redefine.js
@@ -1,0 +1,32 @@
+// add fake Function#toString
+// for correct work wrapped methods / constructors with methods like LoDash isNative
+var global    = require('./_global')
+  , hide      = require('./_hide')
+  , SRC       = require('./_uid')('src')
+  , TO_STRING = 'toString'
+  , $toString = Function[TO_STRING]
+  , TPL       = ('' + $toString).split(TO_STRING);
+
+require('./_core').inspectSource = function(it){
+  return $toString.call(it);
+};
+
+(module.exports = function(O, key, val, safe){
+  if(typeof val == 'function'){
+    val.hasOwnProperty(SRC) || hide(val, SRC, O[key] ? '' + O[key] : TPL.join(String(key)));
+    val.hasOwnProperty('name') || hide(val, 'name', key);
+  }
+  if(O === global){
+    O[key] = val;
+  } else {
+    if(!safe){
+      delete O[key];
+      hide(O, key, val);
+    } else {
+      if(O[key])O[key] = val;
+      else hide(O, key, val);
+    }
+  }
+})(Function.prototype, TO_STRING, function toString(){
+  return typeof this == 'function' && this[SRC] || $toString.call(this);
+});

--- a/test/samples/named-exports-from-object-literal/a.js
+++ b/test/samples/named-exports-from-object-literal/a.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/test/samples/named-exports-from-object-literal/main.js
+++ b/test/samples/named-exports-from-object-literal/main.js
@@ -1,0 +1,4 @@
+import { a, b } from './other.js';
+
+assert.equal( a, 1 );
+assert.equal( b, 2 );

--- a/test/samples/named-exports-from-object-literal/other.js
+++ b/test/samples/named-exports-from-object-literal/other.js
@@ -1,0 +1,7 @@
+var a = require( './a.js' );
+var b = 2;
+
+module.exports = {
+  a: a,
+  b: b
+};

--- a/test/samples/optimise-module-exports-fail/main.js
+++ b/test/samples/optimise-module-exports-fail/main.js
@@ -1,0 +1,2 @@
+var augment = require('augment');
+module.exports = augment( module );

--- a/test/samples/optimise-module-exports/main.js
+++ b/test/samples/optimise-module-exports/main.js
@@ -1,0 +1,2 @@
+var global = require('global');
+module.exports = global.document && document.documentElement;

--- a/test/test.js
+++ b/test/test.js
@@ -6,6 +6,17 @@ var commonjs = require( '..' );
 
 process.chdir( __dirname );
 
+function execute ( code ) {
+	var module = { exports: {} };
+	var fn = new Function( 'module', 'exports', code );
+	fn( module, module.exports );
+	return module;
+}
+
+function executeAssert ( code ) {
+	new Function( 'module', 'assert', code )( {}, assert );
+}
+
 describe( 'rollup-plugin-commonjs', function () {
 	it( 'converts a basic CommonJS module', function () {
 		return rollup.rollup({
@@ -16,12 +27,7 @@ describe( 'rollup-plugin-commonjs', function () {
 				format: 'cjs'
 			});
 
-			var fn = new Function ( 'module', generated.code );
-			var module = {};
-
-			fn( module );
-
-			assert.equal( module.exports, 42 );
+			assert.equal( execute( generated.code ).exports, 42 );
 		});
 	});
 
@@ -34,12 +40,7 @@ describe( 'rollup-plugin-commonjs', function () {
 				format: 'cjs'
 			});
 
-			var fn = new Function ( 'module', generated.code );
-			var module = {};
-
-			fn( module );
-
-			assert.equal( module.exports, 'BARBAZ' );
+			assert.equal( execute( generated.code ).exports, 'BARBAZ' );
 		});
 	});
 
@@ -52,12 +53,7 @@ describe( 'rollup-plugin-commonjs', function () {
 				format: 'cjs'
 			});
 
-			var fn = new Function ( 'module', generated.code );
-			var module = {};
-
-			fn( module );
-
-			assert.equal( module.exports(), 2 );
+			assert.equal( execute( generated.code ).exports(), 2 );
 		});
 	});
 
@@ -95,8 +91,7 @@ describe( 'rollup-plugin-commonjs', function () {
 				format: 'cjs'
 			});
 
-			var fn = new Function ( 'module', 'assert', generated.code );
-			fn( {}, assert );
+			executeAssert( generated.code );
 		});
 	});
 
@@ -109,8 +104,7 @@ describe( 'rollup-plugin-commonjs', function () {
 				format: 'cjs'
 			});
 
-			var fn = new Function ( 'module', 'assert', generated.code );
-			fn( {}, assert );
+			executeAssert( generated.code );
 		});
 	});
 
@@ -125,8 +119,7 @@ describe( 'rollup-plugin-commonjs', function () {
 				format: 'cjs'
 			});
 
-			var fn = new Function ( 'module', 'assert', generated.code );
-			fn( {}, assert );
+			executeAssert( generated.code );
 		});
 	});
 
@@ -139,8 +132,7 @@ describe( 'rollup-plugin-commonjs', function () {
 				format: 'cjs'
 			});
 
-			var fn = new Function ( 'module', 'assert', generated.code );
-			fn( {}, assert );
+			executeAssert( generated.code );
 		});
 	});
 
@@ -153,8 +145,7 @@ describe( 'rollup-plugin-commonjs', function () {
 				format: 'cjs'
 			});
 
-			var fn = new Function ( 'module', 'assert', generated.code );
-			fn( {}, assert );
+			executeAssert( generated.code );
 		});
 	});
 
@@ -167,8 +158,7 @@ describe( 'rollup-plugin-commonjs', function () {
 				format: 'cjs'
 			});
 
-			var fn = new Function ( 'module', 'assert', generated.code );
-			fn( {}, assert );
+			executeAssert( generated.code );
 		});
 	});
 
@@ -184,8 +174,7 @@ describe( 'rollup-plugin-commonjs', function () {
 			assert.ok( generated.code.indexOf( 'module' ) !== -1,
 				'The generated code should contain a "module" variable.' );
 
-			var fn = new Function ( 'module', 'assert', generated.code );
-			fn( {}, assert );
+			executeAssert( generated.code );
 		});
 	});
 
@@ -230,6 +219,72 @@ describe( 'rollup-plugin-commonjs', function () {
 
 			assert.ok( generated.code.indexOf( 'module' ) !== -1,
 				'The generated code should contain a "module" variable.' );
+		});
+	});
+
+	it( 'fails to optimise module.exports reassignments', function () {
+		return rollup.rollup({
+			entry: 'samples/cannot-optimise-module-exports-reassign/main.js',
+			plugins: [ commonjs() ]
+		}).then( function ( bundle ) {
+			var generated = bundle.generate({
+				format: 'cjs'
+			});
+
+			assert.ok( generated.code.indexOf( 'module' ) !== -1,
+				'The generated code should contain a "module" variable.' );
+
+			var module = execute( generated.code );
+
+			assert.equal( module.exports, 2, generated.code );
+		});
+	});
+
+	describe( 'corejs', function () {
+		var external = [
+			'./_core',
+			'./_uid',
+			'./_hide',
+			'./_global'
+		];
+
+		describe( 'can optimise', function () {
+			[
+				'_html',
+				'_path'
+			].forEach(function ( name ) {
+				it( name, function () {
+					return rollup.rollup({
+						entry: 'samples/corejs/' + name + '.js',
+						external: external,
+						plugins: [ commonjs() ]
+					}).then( function ( bundle ) {
+						var generated = bundle.generate();
+
+						assert.ok( generated.code.indexOf( 'function' ) === -1,
+							'The generated code should not contain a "function" wrapper.' );
+					});
+				});
+			});
+		});
+
+		describe( 'can not optimise', function () {
+			[
+				'_redefine'
+			].forEach(function ( name ) {
+				it( name, function () {
+					return rollup.rollup({
+						entry: 'samples/corejs/' + name + '.js',
+						external: external,
+						plugins: [ commonjs() ]
+					}).then( function ( bundle ) {
+						var generated = bundle.generate();
+
+						assert.ok( generated.code.indexOf( name + ' = (function (module) {' ) !== -1,
+							'The generated code should contain a "function" wrapper.' );
+					});
+				});
+			});
 		});
 	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -172,6 +172,20 @@ describe( 'rollup-plugin-commonjs', function () {
 		});
 	});
 
+	it( 'identifies named exports from object literals', function () {
+		return rollup.rollup({
+			entry: 'samples/named-exports-from-object-literal/main.js',
+			plugins: [ commonjs() ]
+		}).then( function ( bundle ) {
+			var generated = bundle.generate({
+				format: 'cjs'
+			});
+
+			var fn = new Function ( 'module', 'assert', generated.code );
+			fn( {}, assert );
+		});
+	});
+
 	it( 'handles references to `global`', function () {
 		return rollup.rollup({
 			entry: 'samples/global/main.js',

--- a/test/test.js
+++ b/test/test.js
@@ -261,8 +261,8 @@ describe( 'rollup-plugin-commonjs', function () {
 					}).then( function ( bundle ) {
 						var generated = bundle.generate();
 
-						assert.ok( generated.code.indexOf( 'function' ) === -1,
-							'The generated code should not contain a "function" wrapper.' );
+						assert.ok( generated.code.indexOf( 'module' ) === -1,
+							'The generated code should not contain a "module" variable.' );
 					});
 				});
 			});
@@ -280,8 +280,8 @@ describe( 'rollup-plugin-commonjs', function () {
 					}).then( function ( bundle ) {
 						var generated = bundle.generate();
 
-						assert.ok( generated.code.indexOf( name + ' = (function (module) {' ) !== -1,
-							'The generated code should contain a "function" wrapper.' );
+						assert.ok( generated.code.indexOf( 'module' ) !== -1,
+							'The generated code should contain a "module" variable.' );
 					});
 				});
 			});

--- a/test/test.js
+++ b/test/test.js
@@ -22,7 +22,7 @@ describe( 'rollup-plugin-commonjs', function () {
 			fn( module );
 
 			assert.equal( module.exports, 42 );
-		})
+		});
 	});
 
 	it( 'converts a CommonJS module that mutates exports instead of replacing', function () {
@@ -40,7 +40,7 @@ describe( 'rollup-plugin-commonjs', function () {
 			fn( module );
 
 			assert.equal( module.exports, 'BARBAZ' );
-		})
+		});
 	});
 
 	it( 'converts inline require calls', function () {
@@ -79,7 +79,7 @@ describe( 'rollup-plugin-commonjs', function () {
 			assert.equal( loc.line, 1 );
 			assert.equal( loc.column, 15 );
 
-			loc = smc.originalPositionFor({ line: 8, column: 8 });
+			loc = smc.originalPositionFor({ line: 6, column: 8 });
 			assert.equal( loc.source, 'samples/sourcemap/main.js' );
 			assert.equal( loc.line, 2 );
 			assert.equal( loc.column, 8 );
@@ -181,6 +181,9 @@ describe( 'rollup-plugin-commonjs', function () {
 				format: 'cjs'
 			});
 
+			assert.ok( generated.code.indexOf( 'module' ) !== -1,
+				'The generated code should contain a "module" variable.' );
+
 			var fn = new Function ( 'module', 'assert', generated.code );
 			fn( {}, assert );
 		});
@@ -201,6 +204,30 @@ describe( 'rollup-plugin-commonjs', function () {
 			fn( window, {} );
 
 			assert.equal( window.foo, 'bar', generated.code );
+		});
+	});
+
+	it( 'optimises module.exports statements', function () {
+		return rollup.rollup({
+			entry: 'samples/optimise-module-exports/main.js',
+			plugins: [ commonjs() ]
+		}).then( function ( bundle ) {
+			var generated = bundle.generate();
+
+			assert.ok( generated.code.indexOf( 'module' ) === -1,
+				'The generated code should not contain a "module" variable.' );
+		});
+	});
+
+	it( 'fails to optimise module.exports statements that `usesModuleOrExports`', function () {
+		return rollup.rollup({
+			entry: 'samples/optimise-module-exports-fail/main.js',
+			plugins: [ commonjs() ]
+		}).then( function ( bundle ) {
+			var generated = bundle.generate();
+
+			assert.ok( generated.code.indexOf( 'module' ) !== -1,
+				'The generated code should contain a "module" variable.' );
 		});
 	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -196,6 +196,20 @@ describe( 'rollup-plugin-commonjs', function () {
 		});
 	});
 
+	it( 'handles bare requires', function () {
+		return rollup.rollup({
+			entry: 'samples/bare/main.js',
+			external: './side-effects',
+			plugins: [ commonjs() ]
+		}).then( function ( bundle ) {
+			var generated = bundle.generate({
+				format: 'es6'
+			});
+
+			assert.equal( generated.code, 'import \'./side-effects\';');
+		});
+	});
+
 	it( 'optimises module.exports statements', function () {
 		return rollup.rollup({
 			entry: 'samples/optimise-module-exports/main.js',

--- a/test/test.js
+++ b/test/test.js
@@ -210,6 +210,7 @@ describe( 'rollup-plugin-commonjs', function () {
 	it( 'optimises module.exports statements', function () {
 		return rollup.rollup({
 			entry: 'samples/optimise-module-exports/main.js',
+			external: [ 'global' ],
 			plugins: [ commonjs() ]
 		}).then( function ( bundle ) {
 			var generated = bundle.generate();
@@ -222,6 +223,7 @@ describe( 'rollup-plugin-commonjs', function () {
 	it( 'fails to optimise module.exports statements that `usesModuleOrExports`', function () {
 		return rollup.rollup({
 			entry: 'samples/optimise-module-exports-fail/main.js',
+			external: [ 'augment' ],
 			plugins: [ commonjs() ]
 		}).then( function ( bundle ) {
 			var generated = bundle.generate();


### PR DESCRIPTION
With this PR we will try to optimise assignments to `module.exports` where we can determine that it's safe.

```js
// example.js
module.exports = function(it){
  return typeof it === 'object' ? it !== null : typeof it === 'function';
}
```

```js
// master branch
var example = (function (module) {
var exports = module.exports;
module.exports = function(it){
  return typeof it === 'object' ? it !== null : typeof it === 'function';
}
return module.exports;
})({exports:{}});

export default example;
```

```js
// optimise-module-exports branch
function example(it){
  return typeof it === 'object' ? it !== null : typeof it === 'function';
}

export default example;
```

@Swatinem Does this fix #4 for you?