### PR TITLE
Optimise wrappers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import { walk } from 'estree-walker';
 import MagicString from 'magic-string';
 import { attachScopes, createFilter, makeLegalIdentifier } from 'rollup-pluginutils';
 import { flatten, isReference } from './ast-utils.js';
+import { staticObject } from './node-test.js';
 
 var firstpass = /\b(?:require|module|exports|global)\b/;
 var exportsPattern = /^(?:module\.)?exports(?:\.([a-zA-Z_$][a-zA-Z_$0-9]*))?$/;
@@ -88,6 +89,12 @@ export default function commonjs ( options = {} ) {
 
 						const match = exportsPattern.exec( flattened.keypath );
 						if ( !match || flattened.keypath === 'exports' ) return;
+
+						if ( flattened.keypath === 'module.exports' && staticObject( node.right ) ) {
+							return node.right.properties.forEach( prop => {
+								namedExports[ prop.key.name ] = true;
+							});
+						}
 
 						if ( match[1] ) namedExports[ match[1] ] = true;
 

--- a/src/index.js
+++ b/src/index.js
@@ -139,10 +139,36 @@ export default function commonjs ( options = {} ) {
 
 					const source = node.arguments[0].value;
 
+					// `require` is called for it's side effects when it's
+					// return value isn't used, for example:
+					//
+					//    require('foo');
+					//
+					//    var a = (require('foo'), require('a'));
+					let calledForSideEffects = parent.type === 'ExpressionStatement' ||
+						( parent.type === 'SequenceExpression' &&
+							parent.expressions[ parent.expressions.length - 1 ] === node );
+
 					let existing = required[ source ];
 					let name;
 
-					if ( !existing ) {
+					if ( calledForSideEffects ) {
+						if ( !existing ) {
+							name = '';
+							required[ source ] = { source, name };
+						}
+
+						// Overwrite with `undefined` to handle both examples. Replacing with
+						// the empty string '' would yield an invalid SequenceExpression.
+						//
+						//   undefined;
+						//
+						//   var a = (undefined, require$$0);
+						magicString.overwrite( node.start, node.end, 'undefined' );
+						return;
+					}
+
+					if ( !existing || !existing.name ) {
 						name = `require$$${uid++}`;
 						required[ source ] = { source, name };
 					} else {
@@ -165,7 +191,7 @@ export default function commonjs ( options = {} ) {
 			const name = getName( id );
 
 			const importBlock = sources.length ?
-				sources.map( source => `import ${required[ source ].name} from '${source}';` ).join( '\n' ) :
+				sources.map( source => `import ${required[ source ].name ? required[ source ].name + ' from ' : ''}'${source}';` ).join( '\n' ) :
 				'';
 
 			const intro = `\n\nvar ${name} = (function (module${usesGlobal ? ', global' : ''}) {\nvar exports = module.exports;\n`;
@@ -189,9 +215,7 @@ export default function commonjs ( options = {} ) {
 			} else {
 				// if we don't need any of the above globals,
 				// we can do some extra optimisations
-				// console.log( magicString.toString() );
 				lazyOptimisations.forEach( fn => fn() );
-				// console.log( magicString.toString() );
 			}
 
 			code = magicString.toString();

--- a/src/node-test.js
+++ b/src/node-test.js
@@ -1,0 +1,21 @@
+export function staticObject ( node ) {
+  return node.type === 'ObjectExpression' && node.properties.every( prop =>
+    !prop.computed && staticValue( prop.value ) );
+}
+
+export function staticMember ( node ) {
+  return node.type === 'MemberExpression' && literal( node.property ) &&
+    ( literal( node.object ) || staticMember( node.object ) );
+}
+
+export function staticValue ( node ) {
+  return literal( node ) || identifier( node ) || staticObject( node ) || staticMember( node );
+}
+
+export function literal ( node ) {
+  return node.type === 'Literal';
+}
+
+export function identifier ( node ) {
+  return node.type === 'Identifier';
+}

--- a/src/node-test.js
+++ b/src/node-test.js
@@ -4,12 +4,22 @@ export function staticObject ( node ) {
 }
 
 export function staticMember ( node ) {
-  return node.type === 'MemberExpression' && literal( node.property ) &&
-    ( literal( node.object ) || staticMember( node.object ) );
+  return node.type === 'MemberExpression' && identifier( node.property ) &&
+    staticValue( node.object );
 }
 
 export function staticValue ( node ) {
-  return literal( node ) || identifier( node ) || staticObject( node ) || staticMember( node );
+  return literal( node ) || identifier( node ) || func( node ) ||
+    staticBinOp( node ) || staticObject( node ) || staticMember( node );
+}
+
+export function staticBinOp ( node ) {
+  return ( node.type === 'BinaryExpression' || node.type === 'LogicalExpression' ) &&
+    staticValue( node.left ) && staticValue( node.right );
+}
+
+export function func ( node ) {
+  return node.type === 'FunctionExpression';
 }
 
 export function literal ( node ) {

--- a/test/samples/bare/main.js
+++ b/test/samples/bare/main.js
@@ -1,0 +1,1 @@
+require('./side-effects');

--- a/test/samples/cannot-optimise-module-exports-reassign/main.js
+++ b/test/samples/cannot-optimise-module-exports-reassign/main.js
@@ -1,0 +1,2 @@
+module.exports = 1;
+module.exports = 2;

--- a/test/samples/corejs/_html.js
+++ b/test/samples/corejs/_html.js
@@ -1,0 +1,1 @@
+module.exports = require('./_global').document && document.documentElement;

--- a/test/samples/corejs/_path.js
+++ b/test/samples/corejs/_path.js
@@ -1,0 +1,1 @@
+module.exports = require('./_global');

--- a/test/samples/corejs/_redefine.js
+++ b/test/samples/corejs/_redefine.js
@@ -1,0 +1,32 @@
+// add fake Function#toString
+// for correct work wrapped methods / constructors with methods like LoDash isNative
+var global    = require('./_global')
+  , hide      = require('./_hide')
+  , SRC       = require('./_uid')('src')
+  , TO_STRING = 'toString'
+  , $toString = Function[TO_STRING]
+  , TPL       = ('' + $toString).split(TO_STRING);
+
+require('./_core').inspectSource = function(it){
+  return $toString.call(it);
+};
+
+(module.exports = function(O, key, val, safe){
+  if(typeof val == 'function'){
+    val.hasOwnProperty(SRC) || hide(val, SRC, O[key] ? '' + O[key] : TPL.join(String(key)));
+    val.hasOwnProperty('name') || hide(val, 'name', key);
+  }
+  if(O === global){
+    O[key] = val;
+  } else {
+    if(!safe){
+      delete O[key];
+      hide(O, key, val);
+    } else {
+      if(O[key])O[key] = val;
+      else hide(O, key, val);
+    }
+  }
+})(Function.prototype, TO_STRING, function toString(){
+  return typeof this == 'function' && this[SRC] || $toString.call(this);
+});

--- a/test/samples/named-exports-from-object-literal/a.js
+++ b/test/samples/named-exports-from-object-literal/a.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/test/samples/named-exports-from-object-literal/main.js
+++ b/test/samples/named-exports-from-object-literal/main.js
@@ -1,0 +1,4 @@
+import { a, b } from './other.js';
+
+assert.equal( a, 1 );
+assert.equal( b, 2 );

--- a/test/samples/named-exports-from-object-literal/other.js
+++ b/test/samples/named-exports-from-object-literal/other.js
@@ -1,0 +1,7 @@
+var a = require( './a.js' );
+var b = 2;
+
+module.exports = {
+  a: a,
+  b: b
+};

--- a/test/samples/optimise-module-exports-fail/main.js
+++ b/test/samples/optimise-module-exports-fail/main.js
@@ -1,0 +1,2 @@
+var augment = require('augment');
+module.exports = augment( module );

--- a/test/samples/optimise-module-exports/main.js
+++ b/test/samples/optimise-module-exports/main.js
@@ -1,0 +1,2 @@
+var global = require('global');
+module.exports = global.document && document.documentElement;

--- a/test/test.js
+++ b/test/test.js
@@ -172,6 +172,20 @@ describe( 'rollup-plugin-commonjs', function () {
 		});
 	});
 
+	it( 'identifies named exports from object literals', function () {
+		return rollup.rollup({
+			entry: 'samples/named-exports-from-object-literal/main.js',
+			plugins: [ commonjs() ]
+		}).then( function ( bundle ) {
+			var generated = bundle.generate({
+				format: 'cjs'
+			});
+
+			var fn = new Function ( 'module', 'assert', generated.code );
+			fn( {}, assert );
+		});
+	});
+
 	it( 'handles references to `global`', function () {
 		return rollup.rollup({
 			entry: 'samples/global/main.js',

--- a/test/test.js
+++ b/test/test.js
@@ -6,6 +6,17 @@ var commonjs = require( '..' );
 
 process.chdir( __dirname );
 
+function execute ( code ) {
+	var module = { exports: {} };
+	var fn = new Function( 'module', 'exports', code );
+	fn( module, module.exports );
+	return module;
+}
+
+function executeAssert ( code ) {
+	new Function( 'module', 'assert', code )( {}, assert );
+}
+
 describe( 'rollup-plugin-commonjs', function () {
 	it( 'converts a basic CommonJS module', function () {
 		return rollup.rollup({
@@ -16,13 +27,8 @@ describe( 'rollup-plugin-commonjs', function () {
 				format: 'cjs'
 			});
 
-			var fn = new Function ( 'module', generated.code );
-			var module = {};
-
-			fn( module );
-
-			assert.equal( module.exports, 42 );
-		})
+			assert.equal( execute( generated.code ).exports, 42 );
+		});
 	});
 
 	it( 'converts a CommonJS module that mutates exports instead of replacing', function () {
@@ -34,13 +40,8 @@ describe( 'rollup-plugin-commonjs', function () {
 				format: 'cjs'
 			});
 
-			var fn = new Function ( 'module', generated.code );
-			var module = {};
-
-			fn( module );
-
-			assert.equal( module.exports, 'BARBAZ' );
-		})
+			assert.equal( execute( generated.code ).exports, 'BARBAZ' );
+		});
 	});
 
 	it( 'converts inline require calls', function () {
@@ -52,12 +53,7 @@ describe( 'rollup-plugin-commonjs', function () {
 				format: 'cjs'
 			});
 
-			var fn = new Function ( 'module', generated.code );
-			var module = {};
-
-			fn( module );
-
-			assert.equal( module.exports(), 2 );
+			assert.equal( execute( generated.code ).exports(), 2 );
 		});
 	});
 
@@ -95,8 +91,7 @@ describe( 'rollup-plugin-commonjs', function () {
 				format: 'cjs'
 			});
 
-			var fn = new Function ( 'module', 'assert', generated.code );
-			fn( {}, assert );
+			executeAssert( generated.code );
 		});
 	});
 
@@ -109,8 +104,7 @@ describe( 'rollup-plugin-commonjs', function () {
 				format: 'cjs'
 			});
 
-			var fn = new Function ( 'module', 'assert', generated.code );
-			fn( {}, assert );
+			executeAssert( generated.code );
 		});
 	});
 
@@ -125,8 +119,7 @@ describe( 'rollup-plugin-commonjs', function () {
 				format: 'cjs'
 			});
 
-			var fn = new Function ( 'module', 'assert', generated.code );
-			fn( {}, assert );
+			executeAssert( generated.code );
 		});
 	});
 
@@ -139,8 +132,7 @@ describe( 'rollup-plugin-commonjs', function () {
 				format: 'cjs'
 			});
 
-			var fn = new Function ( 'module', 'assert', generated.code );
-			fn( {}, assert );
+			executeAssert( generated.code );
 		});
 	});
 
@@ -153,8 +145,7 @@ describe( 'rollup-plugin-commonjs', function () {
 				format: 'cjs'
 			});
 
-			var fn = new Function ( 'module', 'assert', generated.code );
-			fn( {}, assert );
+			executeAssert( generated.code );
 		});
 	});
 
@@ -167,8 +158,7 @@ describe( 'rollup-plugin-commonjs', function () {
 				format: 'cjs'
 			});
 
-			var fn = new Function ( 'module', 'assert', generated.code );
-			fn( {}, assert );
+			executeAssert( generated.code );
 		});
 	});
 
@@ -184,8 +174,7 @@ describe( 'rollup-plugin-commonjs', function () {
 			assert.ok( generated.code.indexOf( 'function' ) !== -1,
 				'The generated code should contain a "function" wrapper.' );
 
-			var fn = new Function ( 'module', 'assert', generated.code );
-			fn( {}, assert );
+			executeAssert( generated.code );
 		});
 	});
 
@@ -217,7 +206,7 @@ describe( 'rollup-plugin-commonjs', function () {
 
 			assert.ok( generated.code.indexOf( 'function' ) === -1,
 				'The generated code should not contain a "function" wrapper.' );
-		})
+		});
 	});
 
 	it( 'fails to optimise module.exports statements that `usesModuleOrExports`', function () {
@@ -230,6 +219,72 @@ describe( 'rollup-plugin-commonjs', function () {
 
 			assert.ok( generated.code.indexOf( 'function' ) !== -1,
 				'The generated code should contain a "function" wrapper.' );
-		})
+		});
+	});
+
+	it( 'fails to optimise module.exports reassignments', function () {
+		return rollup.rollup({
+			entry: 'samples/cannot-optimise-module-exports-reassign/main.js',
+			plugins: [ commonjs() ]
+		}).then( function ( bundle ) {
+			var generated = bundle.generate({
+				format: 'cjs'
+			});
+
+			assert.ok( generated.code.indexOf( 'main = (function (module) {' ) !== -1,
+				'The generated code should contain a "function" wrapper.' );
+
+			var module = execute( generated.code );
+
+			assert.equal( module.exports, 2, generated.code );
+		});
+	});
+
+	describe( 'corejs', function () {
+		var external = [
+			'./_core',
+			'./_uid',
+			'./_hide',
+			'./_global'
+		];
+
+		describe( 'can optimise', function () {
+			[
+				'_html',
+				'_path'
+			].forEach(function ( name ) {
+				it( name, function () {
+					return rollup.rollup({
+						entry: 'samples/corejs/' + name + '.js',
+						external: external,
+						plugins: [ commonjs() ]
+					}).then( function ( bundle ) {
+						var generated = bundle.generate();
+
+						assert.ok( generated.code.indexOf( 'function' ) === -1,
+							'The generated code should not contain a "function" wrapper.' );
+					});
+				});
+			});
+		});
+
+		describe( 'can not optimise', function () {
+			[
+				'_redefine'
+			].forEach(function ( name ) {
+				it( name, function () {
+					return rollup.rollup({
+						entry: 'samples/corejs/' + name + '.js',
+						external: external,
+						plugins: [ commonjs() ]
+					}).then( function ( bundle ) {
+						var generated = bundle.generate();
+
+						assert.ok( generated.code.indexOf( name + ' = (function (module) {' ) !== -1,
+							'The generated code should contain a "function" wrapper.' );
+					});
+				});
+			});
+		});
 	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -79,7 +79,7 @@ describe( 'rollup-plugin-commonjs', function () {
 			assert.equal( loc.line, 1 );
 			assert.equal( loc.column, 15 );
 
-			loc = smc.originalPositionFor({ line: 8, column: 8 });
+			loc = smc.originalPositionFor({ line: 6, column: 8 });
 			assert.equal( loc.source, 'samples/sourcemap/main.js' );
 			assert.equal( loc.line, 2 );
 			assert.equal( loc.column, 8 );
@@ -181,6 +181,9 @@ describe( 'rollup-plugin-commonjs', function () {
 				format: 'cjs'
 			});
 
+			assert.ok( generated.code.indexOf( 'function' ) !== -1,
+				'The generated code should contain a "function" wrapper.' );
+
 			var fn = new Function ( 'module', 'assert', generated.code );
 			fn( {}, assert );
 		});
@@ -202,5 +205,29 @@ describe( 'rollup-plugin-commonjs', function () {
 
 			assert.equal( window.foo, 'bar', generated.code );
 		});
+	});
+
+	it( 'optimises module.exports statements', function () {
+		return rollup.rollup({
+			entry: 'samples/optimise-module-exports/main.js',
+			plugins: [ commonjs() ]
+		}).then( function ( bundle ) {
+			var generated = bundle.generate();
+
+			assert.ok( generated.code.indexOf( 'function' ) === -1,
+				'The generated code should not contain a "function" wrapper.' );
+		})
+	});
+
+	it( 'fails to optimise module.exports statements that `usesModuleOrExports`', function () {
+		return rollup.rollup({
+			entry: 'samples/optimise-module-exports-fail/main.js',
+			plugins: [ commonjs() ]
+		}).then( function ( bundle ) {
+			var generated = bundle.generate();
+
+			assert.ok( generated.code.indexOf( 'function' ) !== -1,
+				'The generated code should contain a "function" wrapper.' );
+		})
 	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -245,7 +245,7 @@ describe( 'rollup-plugin-commonjs', function () {
 				format: 'cjs'
 			});
 
-			assert.ok( generated.code.indexOf( 'main = (function (module) {' ) !== -1,
+			assert.ok( generated.code.indexOf( 'main = __commonjs_wrapper(function (module, exports) {' ) !== -1,
 				'The generated code should contain a "function" wrapper.' );
 
 			var module = execute( generated.code );
@@ -294,7 +294,7 @@ describe( 'rollup-plugin-commonjs', function () {
 					}).then( function ( bundle ) {
 						var generated = bundle.generate();
 
-						assert.ok( generated.code.indexOf( name + ' = (function (module) {' ) !== -1,
+						assert.ok( generated.code.indexOf( name + ' = __commonjs_wrapper(function (module, exports) {' ) !== -1,
 							'The generated code should contain a "function" wrapper.' );
 					});
 				});

--- a/test/test.js
+++ b/test/test.js
@@ -196,6 +196,20 @@ describe( 'rollup-plugin-commonjs', function () {
 		});
 	});
 
+	it( 'handles bare requires', function () {
+		return rollup.rollup({
+			entry: 'samples/bare/main.js',
+			external: './side-effects',
+			plugins: [ commonjs() ]
+		}).then( function ( bundle ) {
+			var generated = bundle.generate({
+				format: 'es6'
+			});
+
+			assert.equal( generated.code, 'import \'./side-effects\';');
+		});
+	});
+
 	it( 'optimises module.exports statements', function () {
 		return rollup.rollup({
 			entry: 'samples/optimise-module-exports/main.js',

--- a/test/test.js
+++ b/test/test.js
@@ -210,6 +210,7 @@ describe( 'rollup-plugin-commonjs', function () {
 	it( 'optimises module.exports statements', function () {
 		return rollup.rollup({
 			entry: 'samples/optimise-module-exports/main.js',
+			external: [ 'global' ],
 			plugins: [ commonjs() ]
 		}).then( function ( bundle ) {
 			var generated = bundle.generate();
@@ -222,6 +223,7 @@ describe( 'rollup-plugin-commonjs', function () {
 	it( 'fails to optimise module.exports statements that `usesModuleOrExports`', function () {
 		return rollup.rollup({
 			entry: 'samples/optimise-module-exports-fail/main.js',
+			external: [ 'augment' ],
 			plugins: [ commonjs() ]
 		}).then( function ( bundle ) {
 			var generated = bundle.generate();


### PR DESCRIPTION
Reduce the overhead of the CommonJS wrappers using a helper function `__commonjs_wrapper`.
```js
function __commonjs_wrapper(fn, module) {
  return module = { exports: {} }, fn(module, module.exports), module.exports;
}
```

Result after minification
```js
// before ~75 bytes
var a=function(o){o.exports;return o.exports=r.Foo,o.exports}({exports:{}})

// after ~35 bytes
var a = r(function(r){r.exports=e.Foo})

// webpack (for comparison) ~35 bytes
function(a,b,c){a.exports=c(5).Foo}
```

See https://github.com/rollup/rollup-plugin-commonjs/pull/12#issuecomment-159878509