### PR TITLE
Add support for transpiled modules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -134,8 +134,17 @@ export default function commonjs ( options = {} ) {
 				sources.map( source => `import ${required[ source ].name} from '${source}';` ).join( '\n' ) :
 				'';
 
-			const intro = `\n\nvar ${name} = (function (module${usesGlobal ? ', global' : ''}) {\nvar exports = module.exports;\n`;
-			let outro = `\nreturn module.exports;\n})({exports:{}}${usesGlobal ? ', __commonjs_global' : ''});\n\nexport default ${name};\n`;
+			const intro = `
+
+var ${name} = (function (module${usesGlobal ? ', global' : ''}) {
+var exports = module.exports;
+`;
+
+			let outro = `
+return module.exports;
+})({exports:{}}${usesGlobal ? ', __commonjs_global' : ''});
+
+export default (${name} && typeof ${name} === 'object' && 'default' in ${name} ? ${name}['default'] : ${name});\n`;
 
 			outro += Object.keys( namedExports ).map( x => `export var ${x} = ${name}.${x};` ).join( '\n' );
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,11 @@ import { flatten, isReference } from './ast-utils.js';
 var firstpass = /\b(?:require|module|exports|global)\b/;
 var exportsPattern = /^(?:module\.)?exports(?:\.([a-zA-Z_$][a-zA-Z_$0-9]*))?$/;
 
+var blacklistedExports = {
+	__esModule: true,
+	default: true
+};
+
 function getName ( id ) {
 	const base = basename( id );
 	const ext = extname( base );
@@ -154,7 +159,10 @@ return module.exports;
 
 export default (${name} && typeof ${name} === 'object' && 'default' in ${name} ? ${name}['default'] : ${name});\n`;
 
-			outro += Object.keys( namedExports ).map( x => `export var ${x} = ${name}.${x};` ).join( '\n' );
+			outro += Object.keys( namedExports )
+				.filter( key => !blacklistedExports[ key ] )
+				.map( x => `export var ${x} = ${name}.${x};` )
+				.join( '\n' );
 
 			magicString.trim()
 				.prepend( importBlock + intro )

--- a/test/samples/__esModule/answer.js
+++ b/test/samples/__esModule/answer.js
@@ -1,0 +1,2 @@
+exports.__esModule = true;
+exports.answer = 42;

--- a/test/samples/__esModule/main.js
+++ b/test/samples/__esModule/main.js
@@ -1,0 +1,2 @@
+exports.__esModule = true;
+exports.answer = 42;

--- a/test/samples/corejs/literal-with-default.js
+++ b/test/samples/corejs/literal-with-default.js
@@ -1,0 +1,1 @@
+module.exports = { default: 'foobar', __esModule: true };

--- a/test/test.js
+++ b/test/test.js
@@ -189,4 +189,22 @@ describe( 'rollup-plugin-commonjs', function () {
 			assert.equal( window.foo, 'bar', generated.code );
 		});
 	});
+
+	it( 'handles transpiled CommonJS modules', function () {
+		return rollup.rollup({
+			entry: 'samples/corejs/literal-with-default.js',
+			plugins: [ commonjs() ]
+		}).then( function ( bundle ) {
+			var generated = bundle.generate({
+				format: 'cjs'
+			});
+
+			var module = {};
+
+			var fn = new Function ( 'module', generated.code );
+			fn( module );
+
+			assert.equal( module.exports, 'foobar', generated.code );
+		});
+	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -172,20 +172,6 @@ describe( 'rollup-plugin-commonjs', function () {
 		});
 	});
 
-	it( 'identifies named exports from object literals', function () {
-		return rollup.rollup({
-			entry: 'samples/named-exports-from-object-literal/main.js',
-			plugins: [ commonjs() ]
-		}).then( function ( bundle ) {
-			var generated = bundle.generate({
-				format: 'cjs'
-			});
-
-			var fn = new Function ( 'module', 'assert', generated.code );
-			fn( {}, assert );
-		});
-	});
-
 	it( 'handles references to `global`', function () {
 		return rollup.rollup({
 			entry: 'samples/global/main.js',
@@ -213,12 +199,30 @@ describe( 'rollup-plugin-commonjs', function () {
 				format: 'cjs'
 			});
 
-			var module = {};
+			var module = { exports: {} };
 
-			var fn = new Function ( 'module', generated.code );
-			fn( module );
+			var fn = new Function ( 'module', 'exports', generated.code );
+			fn( module, module.exports );
 
 			assert.equal( module.exports, 'foobar', generated.code );
+		});
+	});
+
+	it( 'does not export __esModule', function () {
+		return rollup.rollup({
+			entry: 'samples/__esModule/main.js',
+			plugins: [ commonjs() ]
+		}).then( function ( bundle ) {
+			var generated = bundle.generate({
+				format: 'cjs'
+			});
+
+			var fn = new Function ( 'module', 'exports', generated.code );
+			var module = { exports: {} };
+
+			fn( module, module.exports );
+
+			assert.ok( !module.exports.__esModule );
 		});
 	});
 });


### PR DESCRIPTION
_Don't merge yet_

This PR tracks how best to handle CommonJS modules that have already been transpiled by Babel, TypeScript or something similar. These CommonJS modules define a `__esModule` property on their exports object, and export their default export as a `default` property.

We should:
1. remove the `__esModule` property
2. use the `default` property for the default export instead of the `module.exports` object

Fixes #10