### PR TITLE
allow custom named exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 .gobble*
 dist
+!test/node_modules

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "mocha": "^2.3.3",
     "rollup": "^0.22.0",
     "rollup-plugin-babel": "^2.2.0",
+    "rollup-plugin-npm": "^1.1.0",
     "source-map": "^0.5.3"
   },
   "main": "dist/rollup-plugin-commonjs.cjs.js",
@@ -29,6 +30,7 @@
     "acorn": "^2.4.0",
     "estree-walker": "^0.2.0",
     "magic-string": "^0.10.0",
+    "resolve": "^1.1.6",
     "rollup-pluginutils": "^1.2.0"
   },
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import { statSync } from 'fs';
 import { basename, dirname, extname, resolve, sep } from 'path';
+import { sync as nodeResolveSync } from 'resolve';
 import acorn from 'acorn';
 import { walk } from 'estree-walker';
 import MagicString from 'magic-string';
@@ -31,7 +32,15 @@ export default function commonjs ( options = {} ) {
 	let customNamedExports = {};
 	if ( options.namedExports ) {
 		Object.keys( options.namedExports ).forEach( id => {
-			customNamedExports[ resolve( id ) ] = options.namedExports[ id ];
+			let resolvedId;
+
+			try {
+				resolvedId = nodeResolveSync( id, { basedir: process.cwd() });
+			} catch ( err ) {
+				resolvedId = resolve( id );
+			}
+
+			customNamedExports[ resolvedId ] = options.namedExports[ id ];
 		});
 	}
 

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,13 @@ export default function commonjs ( options = {} ) {
 
 	const sourceMap = options.sourceMap !== false;
 
+	let customNamedExports = {};
+	if ( options.namedExports ) {
+		Object.keys( options.namedExports ).forEach( id => {
+			customNamedExports[ resolve( id ) ] = options.namedExports[ id ];
+		});
+	}
+
 	return {
 		resolveId ( importee, importer ) {
 			if ( importee[0] !== '.' ) return; // not our problem
@@ -70,8 +77,12 @@ export default function commonjs ( options = {} ) {
 			let uid = 0;
 
 			let scope = attachScopes( ast, 'scope' );
-			let namedExports = {};
 			let uses = { module: false, exports: false, global: false };
+
+			let namedExports = {};
+			if ( customNamedExports[ id ] ) {
+				customNamedExports[ id ].forEach( name => namedExports[ name ] = true );
+			}
 
 			walk( ast, {
 				enter ( node, parent ) {
@@ -138,7 +149,12 @@ export default function commonjs ( options = {} ) {
 
 			const sources = Object.keys( required );
 
-			if ( !sources.length && !uses.module && !uses.exports && !uses.global ) return null; // not a CommonJS module
+			if ( !sources.length && !uses.module && !uses.exports && !uses.global ) {
+				if ( Object.keys( customNamedExports ).length ) {
+					throw new Error( `Custom named exports were specified for ${id} but it does not appear to be a CommonJS module` );
+				}
+				return null; // not a CommonJS module
+			}
 
 			bundleRequiresWrappers = true;
 

--- a/test/node_modules/external/index.js
+++ b/test/node_modules/external/index.js
@@ -1,0 +1,2 @@
+var externalLib = exports;
+externalLib.message = 'it works';

--- a/test/samples/custom-named-exports/main.js
+++ b/test/samples/custom-named-exports/main.js
@@ -1,0 +1,3 @@
+import { named } from './secret-named-exporter.js';
+
+assert.equal( named, 42 );

--- a/test/samples/custom-named-exports/main.js
+++ b/test/samples/custom-named-exports/main.js
@@ -1,3 +1,5 @@
 import { named } from './secret-named-exporter.js';
+import { message } from 'external';
 
 assert.equal( named, 42 );
+assert.equal( message, 'it works' );

--- a/test/samples/custom-named-exports/secret-named-exporter.js
+++ b/test/samples/custom-named-exports/secret-named-exporter.js
@@ -1,0 +1,2 @@
+var myLib = exports;
+myLib.named = 42;

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,7 @@ import * as path from 'path';
 import * as assert from 'assert';
 import { SourceMapConsumer } from 'source-map';
 import { rollup } from 'rollup';
+import npm from 'rollup-plugin-npm';
 import commonjs from '..';
 
 process.chdir( __dirname );
@@ -174,9 +175,11 @@ describe( 'rollup-plugin-commonjs', () => {
 		return rollup({
 			entry: 'samples/custom-named-exports/main.js',
 			plugins: [
+				npm({ main: true }),
 				commonjs({
 					namedExports: {
-						'samples/custom-named-exports/secret-named-exporter.js': [ 'named' ]
+						'samples/custom-named-exports/secret-named-exporter.js': [ 'named' ],
+						'external': [ 'message' ]
 					}
 				})
 			]

--- a/test/test.js
+++ b/test/test.js
@@ -169,4 +169,17 @@ describe( 'rollup-plugin-commonjs', () => {
 			assert.ok( !module.exports.__esModule );
 		});
 	});
+
+	it( 'allows named exports to be added explicitly via config', () => {
+		return rollup({
+			entry: 'samples/custom-named-exports/main.js',
+			plugins: [
+				commonjs({
+					namedExports: {
+						'samples/custom-named-exports/secret-named-exporter.js': [ 'named' ]
+					}
+				})
+			]
+		}).then( executeBundle );
+	});
 });


### PR DESCRIPTION
Follow-up to #18. Allows build config to specify named exports per module, e.g. in cases like [this](https://github.com/rollup/rollup/issues/366).

* [ ] update documentation