### PR TITLE
Add file extensions configuration option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,22 @@ function getName ( id ) {
 	return makeLegalIdentifier( ext.length ? base.slice( 0, -ext.length ) : base );
 }
 
+function getCandidatesForExtension ( resolved, extension ) {
+	return [
+		resolved + extension,
+		resolved + `${sep}index${extension}`
+	];
+}
+
+function getCandidates ( resolved, extensions ) {
+	return extensions.reduce(
+		( paths, extension ) => paths.concat( getCandidatesForExtension ( resolved, extension ) ),
+		[resolved]
+	);
+}
+
 export default function commonjs ( options = {} ) {
+	const extensions = options.extensions || ['.js'];
 	const filter = createFilter( options.include, options.exclude );
 	let bundleUsesGlobal = false;
 	let bundleRequiresWrappers = false;
@@ -33,11 +48,7 @@ export default function commonjs ( options = {} ) {
 			if ( importee[0] !== '.' ) return; // not our problem
 
 			const resolved = resolve( dirname( importer ), importee );
-			const candidates = [
-				resolved,
-				resolved + '.js',
-				resolved + `${sep}index.js`
-			];
+			const candidates = getCandidates( resolved, extensions );
 
 			for ( let i = 0; i < candidates.length; i += 1 ) {
 				try {
@@ -49,7 +60,7 @@ export default function commonjs ( options = {} ) {
 
 		transform ( code, id ) {
 			if ( !filter( id ) ) return null;
-			if ( extname( id ) !== '.js' ) return null;
+			if ( extensions.indexOf( extname( id ) ) === -1 ) return null;
 			if ( !firstpass.test( code ) ) return null;
 
 			let ast;

--- a/test/samples/extension/foo.coffee
+++ b/test/samples/extension/foo.coffee
@@ -1,0 +1,1 @@
+module.exports = 21;

--- a/test/samples/extension/main.coffee
+++ b/test/samples/extension/main.coffee
@@ -1,0 +1,2 @@
+var foo = require( './foo' );
+module.exports = foo * 2;

--- a/test/test.js
+++ b/test/test.js
@@ -169,4 +169,13 @@ describe( 'rollup-plugin-commonjs', () => {
 			assert.ok( !module.exports.__esModule );
 		});
 	});
+
+	it( 'converts a CommonJS module with custom file extension', () => {
+		return rollup({
+			entry: 'samples/extension/main.coffee',
+			plugins: [ commonjs({ extensions: ['.coffee' ]}) ]
+		}).then( bundle => {
+			assert.equal( executeBundle( bundle ).exports, 42 );
+		});
+	});
 });


### PR DESCRIPTION
Enable processing commonjs requires from non-JS files when explicitly added to the list of supported extensions. This is useful for implementing support for languages compile to JS such as CoffeeScript.