### PR TITLE
Use named exports as a function when no default export is defined

### DIFF
--- a/test/samples/fallback-no-default/foo.js
+++ b/test/samples/fallback-no-default/foo.js
@@ -1,0 +1,3 @@
+export var one = 1;
+
+export var two = 2;

--- a/test/samples/fallback-no-default/main.js
+++ b/test/samples/fallback-no-default/main.js
@@ -1,0 +1,4 @@
+var foo = require('./foo.js');
+
+assert.equal( foo.one, 1 );
+assert.equal( foo.two, 2 );

--- a/test/test.js
+++ b/test/test.js
@@ -64,12 +64,12 @@ describe( 'rollup-plugin-commonjs', () => {
 			let loc = smc.originalPositionFor({ line: 5, column: 17 }); // 42
 			assert.equal( loc.source, 'samples/sourcemap/foo.js' );
 			assert.equal( loc.line, 1 );
-			assert.equal( loc.column, 15 );
+			assert.equal( loc.column, 18 );
 
 			loc = smc.originalPositionFor({ line: 9, column: 8 }); // log
 			assert.equal( loc.source, 'samples/sourcemap/main.js' );
-			assert.equal( loc.line, 2 );
-			assert.equal( loc.column, 8 );
+			assert.equal( loc.line, 1 );
+			assert.equal( loc.column, 7 );
 		});
 	});
 
@@ -219,6 +219,13 @@ describe( 'rollup-plugin-commonjs', () => {
 	it( 'rewrites top-level this expressions', () => {
 		return rollup({
 			entry: 'samples/this/main.js',
+			plugins: [ commonjs() ]
+		}).then( executeBundle );
+	});
+
+	it( 'falls back to object of exports without default export', () => {
+		return rollup({
+			entry: 'samples/fallback-no-default/main.js',
 			plugins: [ commonjs() ]
 		}).then( executeBundle );
 	});


### PR DESCRIPTION
Fixes https://github.com/rollup/rollup/issues/524

Will allow commonjs modules to import es modules when no default is defined. A lot of modules still rely on the nodejs way: The ability to import an object of exports when using `require`. Rollup didn’t allow that, until now :)