### PR TITLE
remove 'global' from test

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import MagicString from 'magic-string';
 import { attachScopes, createFilter, makeLegalIdentifier } from 'rollup-pluginutils';
 import { flatten, isReference } from './ast-utils.js';
 
-var firstpass = /\b(?:require|module|exports|global)\b/;
+var firstpass = /\b(?:require|module|exports)\b/;
 var exportsPattern = /^(?:module\.)?exports(?:\.([a-zA-Z_$][a-zA-Z_$0-9]*))?$/;
 
 const reserved = 'abstract arguments boolean break byte case catch char class const continue debugger default delete do double else enum eval export extends false final finally float for function goto if implements import in instanceof int interface let long native new null package private protected public return short static super switch synchronized this throw throws transient true try typeof var void volatile while with yield'.split( ' ' );


### PR DESCRIPTION
while global is usually associated with nodejs/browserify, it isn't really related and could show up in other contexts (like if somebody is using it for similar purposes in an es6 module)