### PR TITLE
more robust statement defining `global` based on browserify (#50)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -230,7 +230,7 @@ export default function commonjs ( options = {} ) {
 			var intros = [];
 
 			if ( bundleUsesGlobal ) {
-				intros.push( `var __commonjs_global = typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : this;` );
+				intros.push( `var __commonjs_global = typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {}` );
 			}
 
 			if ( bundleRequiresWrappers ) {

--- a/test/test.js
+++ b/test/test.js
@@ -126,12 +126,24 @@ describe( 'rollup-plugin-commonjs', () => {
 				format: 'cjs'
 			});
 
-			let window = {};
+			let mockWindow = {};
+			let mockGlobal = {};
+			let mockSelf = {};
 
-			const fn = new Function ( 'window', 'module', generated.code );
-			fn( window, {} );
+			const fn = new Function ( 'module', 'window', 'global', 'self', generated.code );
 
-			assert.equal( window.foo, 'bar', generated.code );
+			fn( {}, mockWindow, mockGlobal,  mockSelf);
+			assert.equal( mockWindow.foo, 'bar', generated.code );
+			assert.equal( mockGlobal.foo, undefined, generated.code );
+			assert.equal( mockSelf.foo, undefined, generated.code );
+
+			fn( {}, undefined, mockGlobal,  mockSelf );
+			assert.equal( mockGlobal.foo, 'bar', generated.code );
+			assert.equal( mockSelf.foo, undefined, generated.code );
+
+			fn( {}, undefined, undefined, mockSelf );
+			assert.equal( mockSelf.foo, 'bar', generated.code );
+
 		});
 	});
 


### PR DESCRIPTION
though ordering has been switched to make the more likely use case come first