### PR TITLE
more nuanced check for wrapping (#53)

### DIFF
--- a/test/samples/references-require/encoder.js
+++ b/test/samples/references-require/encoder.js
@@ -1,0 +1,33 @@
+var _foo;
+(function outer ( modules, cache, entry ) {
+	// Save the require from previous bundle to this closure if any
+	var previousRequire = typeof require == 'function' && require;
+
+	function newRequire ( name ) {
+		if (!cache[name]) {
+			if (!modules[name]) {
+				if (previousRequire) return previousRequire(name, true);
+			}
+			var m = cache[name] = {
+				exports: {}
+			};
+			modules[name][0].call( m.exports, function ( x ) {
+				var id = modules[name][1][x];
+				return newRequire(id ? id : x);
+			}, m, m.exports, outer, modules, cache, entry);
+		}
+		return cache[name].exports;
+	}
+	var mod = {
+		exports: {}
+	};
+	(function ( require, module) {
+		(function ( global) {
+			module.exports = function ( data) {
+				return global.encodeURIComponent(data);
+			};
+			_foo = module.exports;
+		}).call(this, typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : typeof window !== 'undefined' ? window : {});
+	}.call(this, newRequire, mod, mod.exports));
+}());
+export default _foo;

--- a/test/samples/references-require/main.js
+++ b/test/samples/references-require/main.js
@@ -1,0 +1,5 @@
+import encoder from './encoder';
+
+export function encode(data) {
+  return encoder(data);
+}

--- a/test/test.js
+++ b/test/test.js
@@ -254,4 +254,24 @@ describe( 'rollup-plugin-commonjs', () => {
 			assert.equal( global.setImmediate, mod.immediate, generated.code );
 		});
 	});
+
+	it( 'can handle references to `require`', () => {
+		return rollup({
+			entry: 'samples/references-require/main.js',
+			plugins: [ commonjs() ]
+		}).then( bundle => {
+			const generated = bundle.generate({
+				format: 'cjs'
+			});
+			var exp = {};
+			let mod = {
+				exports: exp
+			};
+
+			const fn = new Function ( 'module', 'exports', generated.code );
+			fn( mod, exp );
+
+			assert.equal( exp.encode('///'), '%2F%2F%2F', generated.code );
+		});
+	});
 });


### PR DESCRIPTION
this should help cases where require (specifically) is referenced but never used and all cases where module, exports, global, or require are used in a typeof or a conditional so 

```js
var mod = typeof exports !== 'undefined' ? exports: {};
var __commonjs_global = typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
var isNode = typeof require === 'function';
```

And using global NEVER triggers wrapping when ignoreGlobal is set.

test features real in the wild code that triggered this.