### PR TITLE
Add rollup config to distributed package

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "files": [
     "src",
     "dist",
-    "README.md"
+    "README.md",
+    "rollup.config.js"
   ],
   "dependencies": {
     "acorn": "^2.4.0",


### PR DESCRIPTION
- Postinstall script would fail and hence the compiled files would not
  exist