### PR TITLE
Transform typeof require to 'function'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -144,6 +144,16 @@ export default function commonjs ( options = {} ) {
 						return;
 					}
 
+					// To allow consumption of UMD modules, transform `typeof require` to `'function'`
+					if ( node.type === 'UnaryExpression' && node.operator === 'typeof' && node.argument.type === 'Identifier' ) {
+						const name = node.argument.name;
+
+						if ( name === 'require' && !scope.contains( name ) ) {
+							magicString.overwrite( node.start, node.end, `'function'` );
+							return;
+						}
+					}
+
 					if ( node.type === 'Identifier' ) {
 						if ( ( node.name in uses && !uses[ node.name ] ) && isReference( node, parent ) && !scope.contains( node.name ) ) uses[ node.name ] = true;
 						return;

--- a/test/samples/umd/correct-scoping.js
+++ b/test/samples/umd/correct-scoping.js
@@ -1,0 +1,5 @@
+if ( typeof require === 'function' ) {
+	module.exports = function ( require ) {
+		return typeof require;
+	}( {} );
+}

--- a/test/samples/umd/protobuf.js
+++ b/test/samples/umd/protobuf.js
@@ -1,0 +1,11 @@
+// From https://github.com/rollup/rollup-plugin-commonjs/issues/38
+(function(global, factory) {
+    /* AMD */ if (typeof define === 'function' && define["amd"])
+        define(["bytebuffer"], factory);
+    /* CommonJS */ else if (typeof require === "function" && typeof module === "object" && module && module["exports"])
+        module["exports"] = factory(require("bytebuffer"), true);
+    /* Global */ else
+        (global["dcodeIO"] = global["dcodeIO"] || {})["ProtoBuf"] = factory(global["dcodeIO"]["ByteBuffer"]);
+})(this, function(ByteBuffer, isCommonJS) {
+  return isCommonJS;
+})

--- a/test/samples/umd/sinon.js
+++ b/test/samples/umd/sinon.js
@@ -1,0 +1,40 @@
+// From https://github.com/rollup/rollup-plugin-commonjs/issues/38
+var sinon = (function () { // eslint-disable-line no-unused-vars
+    "use strict";
+
+    var sinonModule;
+    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
+    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
+
+    function loadDependencies(require, exports, module) {
+        sinonModule = module.exports = require("./sinon/util/core");
+        require("./sinon/extend");
+        require("./sinon/walk");
+        require("./sinon/typeOf");
+        require("./sinon/times_in_words");
+        require("./sinon/spy");
+        require("./sinon/call");
+        require("./sinon/behavior");
+        require("./sinon/stub");
+        require("./sinon/mock");
+        require("./sinon/collection");
+        require("./sinon/assert");
+        require("./sinon/sandbox");
+        require("./sinon/test");
+        require("./sinon/test_case");
+        require("./sinon/match");
+        require("./sinon/format");
+        require("./sinon/log_error");
+    }
+
+    if (isAMD) {
+        define(loadDependencies);
+    } else if (isNode) {
+        loadDependencies(require, module.exports, module);
+        sinonModule = module.exports;
+    } else {
+        sinonModule = {};
+    }
+
+    return sinonModule;
+}());


### PR DESCRIPTION
This change is long overdue. Consuming UMD modules with the commonjs plugin has been a real pain. The problem is solved by transforming top-level `typeof require` expressions to `'function'`.

Fixes #38