### PR TITLE
Test in more node environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ sudo: false
 language: node_js
 node_js:
   - "0.12"
+  - "4"
   - "5"
+  - "node"
 env:
   global:
     - BUILD_TIMEOUT=10000

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,8 @@ environment:
     # node.js
     - nodejs_version: 0.12
     - nodejs_version: 4
+    - nodejs_version: 5
+    - nodejs_version: 6
 
 install:
   - ps: Install-Product node $env:nodejs_version


### PR DESCRIPTION
Related to #63, this plugin should probably be tested in both the current stable version (`"node"`) as well as the current LTS version (`"4"`).