### PR TITLE
WIP: more complete CJS <-> ES interop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,8 +49,10 @@ const HELPERS_ID = '\0commonjsHelpers';
 const HELPERS = `
 export var commonjsGlobal = typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {}
 
-export function interopDefault(ex) {
-	return ex && typeof ex === 'object' && 'default' in ex ? ex['default'] : ex;
+export function interopDefault(x) {
+	if ( !x || typeof x !== 'object' || !x.default ) return x;
+	if ( typeof x['default'] === 'object' || typeof x['default'] === 'function' ) x['default']['default'] = x['default'];
+	return x['default'];
 }
 
 export function createCommonjsModule(fn, module) {
@@ -125,7 +127,7 @@ export default function commonjs ( options = {} ) {
 			// Because objects have no guaranteed ordering, yet we need it,
 			// we need to keep track of the order in a array
 			let sources = [];
-			
+
 			let uid = 0;
 
 			let scope = attachScopes( ast, 'scope' );

--- a/test/samples/react-apollo/commonjs-bar.js
+++ b/test/samples/react-apollo/commonjs-bar.js
@@ -1,0 +1,6 @@
+function Bar () {
+	this.x = 42;
+}
+
+exports.__esModule = true;
+exports.default = Bar;

--- a/test/samples/react-apollo/commonjs-foo.js
+++ b/test/samples/react-apollo/commonjs-foo.js
@@ -1,0 +1,4 @@
+var Bar = require( './commonjs-bar' );
+
+exports.__esModule = true;
+exports.Bar = Bar.default;

--- a/test/samples/react-apollo/main.js
+++ b/test/samples/react-apollo/main.js
@@ -1,0 +1,3 @@
+import { Bar } from './commonjs-foo.js';
+
+assert.equal( new Bar().x, 42 );

--- a/test/test.js
+++ b/test/test.js
@@ -370,4 +370,11 @@ describe( 'rollup-plugin-commonjs', () => {
 			plugins: [ commonjs() ]
 		}).then( executeBundle );
 	});
+
+	it( 'does not remove .default properties', () => {
+		return rollup({
+			entry: 'samples/react-apollo/main.js',
+			plugins: [ commonjs() ]
+		}).then( executeBundle );
+	});
 });


### PR DESCRIPTION
Via rollup/rollup#866. Interop between CommonJS and ES modules continues to be a total bloody nightmare. I think our current approach is incomplete but I'm not sure what the best one is. Stream of consciousness ahead as I try to get my thoughts straight.

There are three situations this plugin needs to handle: ES imports CJS, CJS imports CJS, CJS imports ES.

Right now there's interop fudging at export time *and* at `require` time. It causes problems when CJS files require other CJS files that were generated by a transpiler, as is the case in rollup/rollup#866 – [react-apollo/index.js](https://npmcdn.com/react-apollo@0.4.7/index.js) does things like this:

```js
var ApolloProvider_1 = require('./ApolloProvider');
exports.ApolloProvider = ApolloProvider_1.default;
```

This plugin borks things up because it massages the exports of `ApolloProvider` on the assumption that the importer will be an ES module, not another CJS module.

Taking each situation in turn:

## ES imports CJS

```js
import foo from './commonjs/foo.js';
import { bar } from './commonjs/bar.js';
```

This case is *relatively* straightforward – `foo.js` just exports the value of `module.exports` (or `module.exports.default` if it's a transpiler-generated module – tbh we should probably only do that if `exports.__esModule === true`, because that's how transpilers mark their territory). `bar.js` has a named `bar` export in addition (either automatically, because the plugin detects an `exports.bar = whatever`' assignment, or manually because we've used `options.namedExports`.


## CJS imports CJS

```js
const x = require( './commonjs/foo.js' );
```

It seems fair to say that in this situation, no export massaging should occur – `x` should simply be the value of `module.exports` in `foo.js`. That's not what currently happens, meaning that when a CommonJS module expects to find a `.default` property on a required module, things blow up.

Unfortunately, there's no (robust, reliable) way for this plugin transformer to know whether its consumer will be ES or CJS (or both!).


## CJS imports ES

```js
const y = require( './es/bar.js' );
```

Because of this requirement, all `require` statements result in *namespace imports* rather than default imports – since we don't know if `bar.js` exports `default` or not, we have to import a namespace and futz around with it. This is really bad news, because it results in more code and complexity and prevents tree-shaking.

-----

The approach in https://github.com/rollup/rollup-plugin-commonjs/commit/61c6e00e61134990ce4c92553affc2a8e562056e fixes rollup/rollup#866 but in a horrible way – by adding a `.default` property to the `.default` property, so that an importer of the transformed module will find what it expects whether it's ES or CJS. (It doesn't currently hang any named properties off the default export, so isn't a complete solution in any case.)

There has to be a better way. I'm wondering about something involving virtual 'proxy' modules that do the interop stuff – i.e. an ES module imports the transformed module directly, whereas a CJS module imports the proxy. Or vice versa! Though my thinking hasn't progressed far beyond that right now.

If anyone can see anything obvious I'm missing let me know... you might save me from being driven insane by this stuff.