### PR TITLE
[WIP] BREAKING: interop, take 2

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,23 +1,24 @@
 {
-	"rules": {
-		"indent": [ 2, "tab", { "SwitchCase": 1 } ],
-		"quotes": [ 2, "single" ],
-		"linebreak-style": [ 2, "unix" ],
-		"semi": [ 2, "always" ],
-		"space-after-keywords": [ 2, "always" ],
-		"space-before-blocks": [ 2, "always" ],
-		"space-before-function-paren": [ 2, "always" ],
-		"no-mixed-spaces-and-tabs": [ 2, "smart-tabs" ],
-		"no-cond-assign": [ 0 ]
-	},
-	"env": {
-		"es6": true,
-		"browser": true,
-		"mocha": true,
-		"node": true
-	},
-	"extends": "eslint:recommended",
-	"ecmaFeatures": {
-		"modules": true
-	}
+  "rules": {
+    "indent": [ 2, "tab", { "SwitchCase": 1 } ],
+    "quotes": [ 2, "single", { "allowTemplateLiterals": true } ],
+    "linebreak-style": [ 2, "unix" ],
+    "semi": [ 2, "always" ],
+    "keyword-spacing": [ 2, { "before": true, "after": true } ],
+    "space-before-blocks": [ 2, "always" ],
+    "space-before-function-paren": [ 2, "always" ],
+    "no-mixed-spaces-and-tabs": [ 2, "smart-tabs" ],
+    "no-cond-assign": [ 0 ]
+  },
+  "env": {
+    "es6": true,
+    "browser": true,
+    "mocha": true,
+    "node": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "rollup": "^0.33.0",
     "rollup-plugin-buble": "^0.12.1",
     "rollup-plugin-node-resolve": "^1.7.1",
-    "source-map": "^0.5.6"
+    "source-map": "^0.5.6",
+    "source-map-support": "^0.4.2"
   },
   "main": "dist/rollup-plugin-commonjs.cjs.js",
   "jsnext:main": "dist/rollup-plugin-commonjs.es.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,11 @@ var external = Object.keys( require( './package.json' ).dependencies ).concat([ 
 
 export default {
 	entry: 'src/index.js',
-	plugins: [ buble() ],
-	external: external
+	plugins: [
+		buble({
+			transforms: { dangerousForOf: true }
+		})
+	],
+	external: external,
+	sourceMap: true
 };

--- a/src/defaultResolver.js
+++ b/src/defaultResolver.js
@@ -1,0 +1,39 @@
+import * as fs from 'fs';
+import { dirname, resolve } from 'path';
+
+function isFile ( file ) {
+	try {
+		const stats = fs.statSync( file );
+		return stats.isFile();
+	} catch ( err ) {
+		return false;
+	}
+}
+
+function addJsExtensionIfNecessary ( file ) {
+	if ( isFile( file ) ) return file;
+
+	file += '.js';
+	if ( isFile( file ) ) return file;
+
+	return null;
+}
+
+const absolutePath = /^(?:\/|(?:[A-Za-z]:)?[\\|\/])/;
+
+function isAbsolute ( path ) {
+	return absolutePath.test( path );
+}
+
+export default function defaultResolver ( importee, importer ) {
+	// absolute paths are left untouched
+	if ( isAbsolute( importee ) ) return addJsExtensionIfNecessary( resolve( importee ) );
+
+	// if this is the entry point, resolve against cwd
+	if ( importer === undefined ) return addJsExtensionIfNecessary( resolve( process.cwd(), importee ) );
+
+	// external modules are skipped at this stage
+	if ( importee[0] !== '.' ) return null;
+
+	return addJsExtensionIfNecessary( resolve( dirname( importer ), importee ) );
+}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,19 @@
+export const HELPERS_ID = '\0commonjsHelpers';
+
+export const HELPERS = `
+export var commonjsGlobal = typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {}
+
+export function interopDefault(x) {
+	if ( !x || typeof x !== 'object' || !x.default ) return x;
+	return x['default'];
+}
+
+export function unwrapExports (x) {
+	return x && x.__esModule ? x['default'] : x;
+}
+
+export function createCommonjsModule(fn, module) {
+	return module = { exports: {} }, fn(module, module.exports), module.exports;
+}`;
+
+export const PREFIX = '\0commonjs-required:';

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,12 +1,7 @@
 export const HELPERS_ID = '\0commonjsHelpers';
 
 export const HELPERS = `
-export var commonjsGlobal = typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {}
-
-export function interopDefault(x) {
-	if ( !x || typeof x !== 'object' || !x.default ) return x;
-	return x['default'];
-}
+export var commonjsGlobal = typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
 
 export function unwrapExports (x) {
 	return x && x.__esModule ? x['default'] : x;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -11,4 +11,5 @@ export function createCommonjsModule(fn, module) {
 	return module = { exports: {} }, fn(module, module.exports), module.exports;
 }`;
 
-export const PREFIX = '\0commonjs-required:';
+export const PREFIX = '\0commonjs-proxy:';
+export const EXTERNAL = '\0commonjs-external:';

--- a/src/index.js
+++ b/src/index.js
@@ -1,27 +1,16 @@
-import { statSync } from 'fs';
+import { readFileSync, statSync } from 'fs';
 import { basename, dirname, extname, resolve, sep } from 'path';
 import { sync as nodeResolveSync } from 'resolve';
-import acorn from 'acorn';
-import { walk } from 'estree-walker';
+import { createFilter, makeLegalIdentifier } from 'rollup-pluginutils';
 import MagicString from 'magic-string';
-import { attachScopes, createFilter, makeLegalIdentifier } from 'rollup-pluginutils';
-import { flatten, isReference } from './ast-utils.js';
-
-var firstpassGlobal = /\b(?:require|module|exports|global)\b/;
-var firstpassNoGlobal = /\b(?:require|module|exports)\b/;
-var exportsPattern = /^(?:module\.)?exports(?:\.([a-zA-Z_$][a-zA-Z_$0-9]*))?$/;
+import { PREFIX, HELPERS_ID, HELPERS } from './helpers.js';
+import defaultResolver from './defaultResolver.js';
+import transform from './transform.js';
 
 const reserved = 'abstract arguments boolean break byte case catch char class const continue debugger default delete do double else enum eval export extends false final finally float for function goto if implements import in instanceof int interface let long native new null package private protected public return short static super switch synchronized this throw throws transient true try typeof var void volatile while with yield'.split( ' ' );
 
 var blacklistedExports = { __esModule: true };
 reserved.forEach( word => blacklistedExports[ word ] = true );
-
-function getName ( id ) {
-	const base = basename( id );
-	const ext = extname( base );
-
-	return makeLegalIdentifier( ext.length ? base.slice( 0, -ext.length ) : base );
-}
 
 function getCandidatesForExtension ( resolved, extension ) {
 	return [
@@ -37,33 +26,30 @@ function getCandidates ( resolved, extensions ) {
 	);
 }
 
-function deconflict ( identifier, code ) {
-	let i = 1;
-	let deconflicted = identifier;
+function getName ( id ) {
+	const base = basename( id );
+	const ext = extname( base );
 
-	while ( ~code.indexOf( deconflicted ) ) deconflicted = `${identifier}_${i++}`;
-	return deconflicted;
+	return makeLegalIdentifier( ext.length ? base.slice( 0, -ext.length ) : base );
 }
 
-const HELPERS_ID = '\0commonjsHelpers';
-const HELPERS = `
-export var commonjsGlobal = typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {}
-
-export function interopDefault(ex) {
-	return ex && typeof ex === 'object' && 'default' in ex ? ex['default'] : ex;
+// Return the first non-falsy result from an array of
+// maybe-sync, maybe-promise-returning functions
+function first ( candidates ) {
+	return function ( ...args ) {
+		return candidates.reduce( ( promise, candidate ) => {
+			return promise.then( result => result != null ?
+				result :
+				Promise.resolve( candidate( ...args ) ) );
+		}, Promise.resolve() );
+	};
 }
 
-export function createCommonjsModule(fn, module) {
-	return module = { exports: {} }, fn(module, module.exports), module.exports;
-}`;
 
 export default function commonjs ( options = {} ) {
 	const extensions = options.extensions || ['.js'];
 	const filter = createFilter( options.include, options.exclude );
 	const ignoreGlobal = options.ignoreGlobal;
-	const firstpass = ignoreGlobal ? firstpassNoGlobal : firstpassGlobal;
-
-	const sourceMap = options.sourceMap !== false;
 
 	let customNamedExports = {};
 	if ( options.namedExports ) {
@@ -80,200 +66,144 @@ export default function commonjs ( options = {} ) {
 		});
 	}
 
+	function resolveId ( importee, importer ) {
+		if ( importee === HELPERS_ID ) return importee;
+
+		if ( importer ) importer = importer.replace( PREFIX, '' );
+
+		const isImportedByCommonJsModule = importee.startsWith( PREFIX );
+		importee = importee.replace( PREFIX, '' );
+
+		return resolveUsingOtherResolvers( importee, importer ).then( resolved => {
+			if ( resolved ) return isImportedByCommonJsModule ? PREFIX + resolved : resolved;
+
+			if ( isImportedByCommonJsModule ) {
+				// standard resolution procedure
+				const resolved = defaultResolver( importee, importer );
+				if ( resolved ) return PREFIX + resolved;
+			}
+		});
+	}
+
+	let commonjsModules = new Map();
+	function getCommonjsModule ( code, id ) {
+		if ( !commonjsModules.has( id ) ) {
+			commonjsModules.set( id, transform( code, id, ignoreGlobal, customNamedExports[ id ] ) );
+		}
+
+		return commonjsModules.get( id );
+	}
+
+	let resolveUsingOtherResolvers;
+
 	return {
 		name: 'commonjs',
 
-		resolveId ( importee, importer ) {
-			if ( importee === HELPERS_ID ) return importee;
-			if ( importee[0] !== '.' || !importer ) return; // not our problem
+		options ( options ) {
+			const resolvers = ( options.plugins || [] )
+				.map( plugin => {
+					if ( plugin.resolveId === resolveId ) {
+						// substitute CommonJS resolution logic
+						return ( importee, importer ) => {
+							if ( importee[0] !== '.' || !importer ) return; // not our problem
 
-			const resolved = resolve( dirname( importer ), importee );
-			const candidates = getCandidates( resolved, extensions );
+							const resolved = resolve( dirname( importer ), importee );
+							const candidates = getCandidates( resolved, extensions );
 
-			for ( let i = 0; i < candidates.length; i += 1 ) {
-				try {
-					const stats = statSync( candidates[i] );
-					if ( stats.isFile() ) return candidates[i];
-				} catch ( err ) { /* noop */ }
-			}
+							for ( let i = 0; i < candidates.length; i += 1 ) {
+								try {
+									const stats = statSync( candidates[i] );
+									if ( stats.isFile() ) return candidates[i];
+								} catch ( err ) { /* noop */ }
+							}
+						};
+					}
+
+					return plugin.resolveId;
+				})
+				.filter( Boolean );
+
+			resolveUsingOtherResolvers = first( resolvers );
 		},
+
+		resolveId,
 
 		load ( id ) {
 			if ( id === HELPERS_ID ) return HELPERS;
+
+			if ( id.startsWith( PREFIX ) ) {
+				const actualId = id.slice( PREFIX.length );
+				return readFileSync( actualId, 'utf-8' );
+			}
 		},
 
 		transform ( code, id ) {
-			if ( !filter( id ) ) return null;
-			if ( extensions.indexOf( extname( id ) ) === -1 ) return null;
-			if ( !firstpass.test( code ) ) return null;
+			const isImportedByCommonJsModule = id.startsWith( PREFIX );
+			id = id.replace( PREFIX, '' );
 
-			let ast;
-
-			try {
-				ast = acorn.parse( code, {
-					ecmaVersion: 6,
-					sourceType: 'module'
-				});
-			} catch ( err ) {
-				err.message += ` in ${id}`;
-				throw err;
-			}
-
-			const magicString = new MagicString( code );
-
-			let required = {};
-			// Because objects have no guaranteed ordering, yet we need it,
-			// we need to keep track of the order in a array
-			let sources = [];
-			
-			let uid = 0;
-
-			let scope = attachScopes( ast, 'scope' );
-			let uses = { module: false, exports: false, global: false };
-
-			let namedExports = {};
-			if ( customNamedExports[ id ] ) {
-				customNamedExports[ id ].forEach( name => namedExports[ name ] = true );
-			}
-
-			let scopeDepth = 0;
-
-			const HELPERS_NAME = deconflict( 'commonjsHelpers', code );
-
-			walk( ast, {
-				enter ( node, parent ) {
-					if ( node.scope ) scope = node.scope;
-					if ( /^Function/.test( node.type ) ) scopeDepth += 1;
-
-					if ( sourceMap ) {
-						magicString.addSourcemapLocation( node.start );
-						magicString.addSourcemapLocation( node.end );
-					}
-
-					// Is this an assignment to exports or module.exports?
-					if ( node.type === 'AssignmentExpression' ) {
-						if ( node.left.type !== 'MemberExpression' ) return;
-
-						const flattened = flatten( node.left );
-						if ( !flattened ) return;
-
-						if ( scope.contains( flattened.name ) ) return;
-
-						const match = exportsPattern.exec( flattened.keypath );
-						if ( !match || flattened.keypath === 'exports' ) return;
-
-						if ( flattened.keypath === 'module.exports' && node.right.type === 'ObjectExpression' ) {
-							return node.right.properties.forEach( prop => {
-								if ( prop.computed || prop.key.type !== 'Identifier' ) return;
-								const name = prop.key.name;
-								if ( name === makeLegalIdentifier( name ) ) namedExports[ name ] = true;
-							});
-						}
-
-						if ( match[1] ) namedExports[ match[1] ] = true;
-
-						return;
-					}
-
-					// To allow consumption of UMD modules, transform `typeof require` to `'function'`
-					if ( node.type === 'UnaryExpression' && node.operator === 'typeof' && node.argument.type === 'Identifier' ) {
-						const name = node.argument.name;
-
-						if ( name === 'require' && !scope.contains( name ) ) {
-							magicString.overwrite( node.start, node.end, `'function'` );
-							return;
-						}
-					}
-
-					if ( node.type === 'Identifier' ) {
-						if ( ( node.name in uses ) && isReference( node, parent ) && !scope.contains( node.name ) ) {
-							uses[ node.name ] = true;
-							if ( node.name === 'global' ) magicString.overwrite( node.start, node.end, `${HELPERS_NAME}.commonjsGlobal` );
-						}
-						return;
-					}
-
-					if ( node.type === 'ThisExpression' && scopeDepth === 0 && !ignoreGlobal ) {
-						uses.global = true;
-						magicString.overwrite( node.start, node.end, `${HELPERS_NAME}.commonjsGlobal`, true );
-						return;
-					}
-
-					if ( node.type !== 'CallExpression' ) return;
-					if ( node.callee.name !== 'require' || scope.contains( 'require' ) ) return;
-					if ( node.arguments.length !== 1 || node.arguments[0].type !== 'Literal' ) return; // TODO handle these weird cases?
-
-					const source = node.arguments[0].value;
-
-					let existing = required[ source ];
-					if ( existing === undefined ) {
-						sources.unshift(source);
-					}
-					let name;
-
-					if ( !existing ) {
-						name = `require$$${uid++}`;
-						required[ source ] = { source, name, importsDefault: false };
-					} else {
-						name = required[ source ].name;
-					}
-
-					if ( parent.type !== 'ExpressionStatement' ) {
-						required[ source ].importsDefault = true;
-						magicString.overwrite( node.start, node.end, `${HELPERS_NAME}.interopDefault(${name})` );
-					} else {
-						// is a bare import, e.g. `require('foo');`
-						magicString.remove( parent.start, parent.end );
-					}
-				},
-
-				leave ( node ) {
-					if ( node.scope ) scope = scope.parent;
-					if ( /^Function/.test( node.type ) ) scopeDepth -= 1;
-				}
-			});
-
-			if ( !sources.length && !uses.module && !uses.exports && !uses.global ) {
-				if ( Object.keys( namedExports ).length ) {
-					throw new Error( `Custom named exports were specified for ${id} but it does not appear to be a CommonJS module` );
-				}
-				return null; // not a CommonJS module
-			}
+			let transformed;
+			if ( filter( id ) && extensions.indexOf( extname( id ) ) !== -1 ) transformed = getCommonjsModule( code, id );
+			const isCommonJsModule = !!transformed;
 
 			const name = getName( id );
 
-			const importBlock = [ `import * as ${HELPERS_NAME} from '${HELPERS_ID}';` ].concat(
-				sources.map( source => {
-					const { name, importsDefault } = required[ source ];
-					return `import ${importsDefault ? `* as ${name} from ` : ``}'${source}';`;
-				})
-			).join( '\n' );
+			if ( isImportedByCommonJsModule ) {
+				if ( !isCommonJsModule ) {
+					// CJS importing ES – need to import a namespace and re-export as default
+					const code = `import * as ${name} from '${id}'; export default ${name}['default'] || ${name};`;
 
-			const args = `module${uses.exports ? ', exports' : ''}`;
+					return {
+						code,
+						map: { mappings: '' }
+					};
+				}
 
-			const intro = `\n\nvar ${name} = ${HELPERS_NAME}.createCommonjsModule(function (${args}) {\n`;
-			let outro = `\n});\n\nexport default ${HELPERS_NAME}.interopDefault(${name});\n`;
+				// CJS importing CJS – pass module.exports through unmolested
+				return transformed;
+			}
 
-			outro += Object.keys( namedExports )
-				.filter( key => !blacklistedExports[ key ] )
-				.map( x => {
-					if (x === name) {
-						return `var ${x}$$1 = ${name}.${x};\nexport { ${x}$$1 as ${x} };`;
-					} else {
-						return `export var ${x} = ${name}.${x};`;
-					}
-				})
-				.join( '\n' );
+			// ES importing CJS – do the interop dance
+			if ( isCommonJsModule ) {
+				const HELPERS_NAME = 'commonjsHelpers';
 
-			magicString.trim()
-				.prepend( importBlock + intro )
-				.trim()
-				.append( outro );
+				let proxy = `import * as ${HELPERS_NAME} from '${HELPERS_ID}';\nimport ${name} from '${PREFIX}${id}';\n\n`;
+				proxy += /__esModule/.test( code ) ? `export default ${HELPERS_NAME}.unwrapExports(${name});\n` : `export default ${name};\n`;
+				proxy += Object.keys( transformed.namedExports )
+					.filter( key => !blacklistedExports[ key ] )
+					.map( x => {
+						if (x === name) {
+							return `var ${x}$$1 = ${name}.${x};\nexport { ${x}$$1 as ${x} };`;
+						} else {
+							return `export var ${x} = ${name}.${x};`;
+						}
+					})
+					.join( '\n' );
 
-			code = magicString.toString();
-			const map = sourceMap ? magicString.generateMap() : null;
+				return {
+					code: proxy,
+					map: { mappings: '' }
+				};
+			}
 
-			return { code, map };
+			return null;
+		},
+
+		transformBundle ( code ) {
+			// prevent external dependencies from having the prefix
+			const magicString = new MagicString( code );
+			const pattern = new RegExp( PREFIX, 'g' );
+
+			if ( !pattern.test( code ) ) return null;
+
+			let match;
+			while ( match = pattern.exec( code ) ) {
+				magicString.remove( match.index, match[0].length );
+			}
+
+			return {
+				code: magicString.toString(),
+				map: magicString.generateMap({ hires: true })
+			};
 		}
 	};
 }

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ function getCandidates ( resolved, extensions ) {
 }
 
 function getName ( id ) {
-	const base = basename( id );
+	const base = id.split( '/' ).pop();
 	const ext = extname( base );
 
 	return makeLegalIdentifier( ext.length ? base.slice( 0, -ext.length ) : base );

--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ export default function commonjs ( options = {} ) {
 		if ( importer && startsWith( importer, PREFIX ) ) importer = importer.slice( PREFIX.length );
 
 		const isProxyModule = startsWith( importee, PREFIX );
-		if (isProxyModule) importee = importee.slice( PREFIX.length );
+		if ( isProxyModule ) importee = importee.slice( PREFIX.length );
 
 		return resolveUsingOtherResolvers( importee, importer ).then( resolved => {
 			if ( resolved ) return isProxyModule ? PREFIX + resolved : resolved;
@@ -133,7 +133,7 @@ export default function commonjs ( options = {} ) {
 				const actualId = id.slice( EXTERNAL.length );
 				const name = getName( actualId );
 
-				return `import ${name} from ${JSON.stringify(actualId)}; export default ${name};`;
+				return `import ${name} from ${JSON.stringify( actualId )}; export default ${name};`;
 			}
 
 			if ( startsWith( id, PREFIX ) ) {
@@ -141,8 +141,8 @@ export default function commonjs ( options = {} ) {
 				const name = getName( actualId );
 
 				return commonjsModules.has( actualId ) ?
-					`import { __moduleExports } from ${JSON.stringify(actualId)}; export default __moduleExports;` :
-					`import * as ${name} from ${JSON.stringify(actualId)}; export default ( ${name} && ${name}['default'] ) || ${name};`;
+					`import { __moduleExports } from ${JSON.stringify( actualId )}; export default __moduleExports;` :
+					`import * as ${name} from ${JSON.stringify( actualId )}; export default ( ${name} && ${name}['default'] ) || ${name};`;
 			}
 		},
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import { statSync } from 'fs';
-import { basename, dirname, extname, resolve, sep } from 'path';
+import { dirname, extname, resolve, sep } from 'path';
 import { sync as nodeResolveSync } from 'resolve';
 import { createFilter, makeLegalIdentifier } from 'rollup-pluginutils';
 import MagicString from 'magic-string';
@@ -27,7 +27,7 @@ function getCandidates ( resolved, extensions ) {
 }
 
 function getName ( id ) {
-	const base = id.split( '/' ).pop();
+	const base = id.split( /\/\\/ ).pop();
 	const ext = extname( base );
 
 	return makeLegalIdentifier( ext.length ? base.slice( 0, -ext.length ) : base );

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,10 @@ function first ( candidates ) {
 	};
 }
 
+function startsWith ( str, prefix ) {
+	return str.slice( 0, prefix.length ) === prefix;
+}
+
 
 export default function commonjs ( options = {} ) {
 	const extensions = options.extensions || ['.js'];
@@ -71,7 +75,7 @@ export default function commonjs ( options = {} ) {
 
 		if ( importer ) importer = importer.replace( PREFIX, '' );
 
-		const isImportedByCommonJsModule = importee.startsWith( PREFIX );
+		const isImportedByCommonJsModule = startsWith( importee, PREFIX );
 		importee = importee.replace( PREFIX, '' );
 
 		return resolveUsingOtherResolvers( importee, importer ).then( resolved => {
@@ -131,14 +135,14 @@ export default function commonjs ( options = {} ) {
 		load ( id ) {
 			if ( id === HELPERS_ID ) return HELPERS;
 
-			if ( id.startsWith( PREFIX ) ) {
+			if ( startsWith( id, PREFIX ) ) {
 				const actualId = id.slice( PREFIX.length );
 				return readFileSync( actualId, 'utf-8' );
 			}
 		},
 
 		transform ( code, id ) {
-			const isImportedByCommonJsModule = id.startsWith( PREFIX );
+			const isImportedByCommonJsModule = startsWith( id, PREFIX );
 			id = id.replace( PREFIX, '' );
 
 			let transformed;

--- a/src/transform.js
+++ b/src/transform.js
@@ -1,0 +1,172 @@
+import acorn from 'acorn';
+import { walk } from 'estree-walker';
+import MagicString from 'magic-string';
+import { attachScopes, makeLegalIdentifier } from 'rollup-pluginutils';
+import { flatten, isReference } from './ast-utils.js';
+import { PREFIX, HELPERS_ID } from './helpers.js';
+
+var exportsPattern = /^(?:module\.)?exports(?:\.([a-zA-Z_$][a-zA-Z_$0-9]*))?$/;
+
+var firstpassGlobal = /\b(?:require|module|exports|global)\b/;
+var firstpassNoGlobal = /\b(?:require|module|exports)\b/;
+
+function deconflict ( identifier, code ) {
+	let i = 1;
+	let deconflicted = identifier;
+
+	while ( ~code.indexOf( deconflicted ) ) deconflicted = `${identifier}_${i++}`;
+	return deconflicted;
+}
+
+function tryParse ( code, id ) {
+	try {
+		return acorn.parse( code, {
+			ecmaVersion: 6,
+			sourceType: 'module'
+		});
+	} catch ( err ) {
+		err.message += ` in ${id}`;
+		throw err;
+	}
+}
+
+export default function transform ( code, id, ignoreGlobal, customNamedExports ) {
+	const firstpass = ignoreGlobal ? firstpassNoGlobal : firstpassGlobal;
+	if ( !firstpass.test( code ) ) return null;
+
+	let namedExports = {};
+	if ( customNamedExports ) customNamedExports.forEach( name => namedExports[ name ] = true );
+
+	const ast = tryParse( code, id );
+	const magicString = new MagicString( code );
+
+	let required = {};
+	// Because objects have no guaranteed ordering, yet we need it,
+	// we need to keep track of the order in a array
+	let sources = [];
+
+	let uid = 0;
+
+	let scope = attachScopes( ast, 'scope' );
+	let uses = { module: false, exports: false, global: false };
+
+	let scopeDepth = 0;
+
+	const HELPERS_NAME = deconflict( 'commonjsHelpers', code );
+
+	walk( ast, {
+		enter ( node, parent ) {
+			if ( node.scope ) scope = node.scope;
+			if ( /^Function/.test( node.type ) ) scopeDepth += 1;
+
+			// Is this an assignment to exports or module.exports?
+			if ( node.type === 'AssignmentExpression' ) {
+				if ( node.left.type !== 'MemberExpression' ) return;
+
+				const flattened = flatten( node.left );
+				if ( !flattened ) return;
+
+				if ( scope.contains( flattened.name ) ) return;
+
+				const match = exportsPattern.exec( flattened.keypath );
+				if ( !match || flattened.keypath === 'exports' ) return;
+
+				if ( flattened.keypath === 'module.exports' && node.right.type === 'ObjectExpression' ) {
+					return node.right.properties.forEach( prop => {
+						if ( prop.computed || prop.key.type !== 'Identifier' ) return;
+						const name = prop.key.name;
+						if ( name === makeLegalIdentifier( name ) ) namedExports[ name ] = true;
+					});
+				}
+
+				if ( match[1] ) namedExports[ match[1] ] = true;
+
+				return;
+			}
+
+			// To allow consumption of UMD modules, transform `typeof require` to `'function'`
+			if ( node.type === 'UnaryExpression' && node.operator === 'typeof' && node.argument.type === 'Identifier' ) {
+				const name = node.argument.name;
+
+				if ( name === 'require' && !scope.contains( name ) ) {
+					magicString.overwrite( node.start, node.end, `'function'` );
+					return;
+				}
+			}
+
+			if ( node.type === 'Identifier' ) {
+				if ( ( node.name in uses ) && isReference( node, parent ) && !scope.contains( node.name ) ) {
+					uses[ node.name ] = true;
+					if ( node.name === 'global' ) magicString.overwrite( node.start, node.end, `${HELPERS_NAME}.commonjsGlobal` );
+				}
+				return;
+			}
+
+			if ( node.type === 'ThisExpression' && scopeDepth === 0 && !ignoreGlobal ) {
+				uses.global = true;
+				magicString.overwrite( node.start, node.end, `${HELPERS_NAME}.commonjsGlobal`, true );
+				return;
+			}
+
+			if ( node.type !== 'CallExpression' ) return;
+			if ( node.callee.name !== 'require' || scope.contains( 'require' ) ) return;
+			if ( node.arguments.length !== 1 || node.arguments[0].type !== 'Literal' ) return; // TODO handle these weird cases?
+
+			const source = node.arguments[0].value;
+
+			let existing = required[ source ];
+			if ( existing === undefined ) {
+				sources.unshift(source);
+			}
+			let name;
+
+			if ( !existing ) {
+				name = `require$$${uid++}`;
+				required[ source ] = { source, name, importsDefault: false };
+			} else {
+				name = required[ source ].name;
+			}
+
+			if ( parent.type !== 'ExpressionStatement' ) {
+				required[ source ].importsDefault = true;
+				magicString.overwrite( node.start, node.end, name );
+			} else {
+				// is a bare import, e.g. `require('foo');`
+				magicString.remove( parent.start, parent.end );
+			}
+		},
+
+		leave ( node ) {
+			if ( node.scope ) scope = scope.parent;
+			if ( /^Function/.test( node.type ) ) scopeDepth -= 1;
+		}
+	});
+
+	if ( !sources.length && !uses.module && !uses.exports && !uses.global ) {
+		if ( Object.keys( namedExports ).length ) {
+			throw new Error( `Custom named exports were specified for ${id} but it does not appear to be a CommonJS module` );
+		}
+		return null; // not a CommonJS module
+	}
+
+	const importBlock = [ `import * as ${HELPERS_NAME} from '${HELPERS_ID}';` ].concat(
+		sources.map( source => {
+			const { name, importsDefault } = required[ source ];
+			return `import ${importsDefault ? `${name} from ` : ``}'${PREFIX}${source}';`;
+		})
+	).join( '\n' );
+
+	const args = `module${uses.exports ? ', exports' : ''}`;
+
+	const wrapperStart = `\n\nexport default ${HELPERS_NAME}.createCommonjsModule(function (${args}) {\n`;
+	const wrapperEnd = `\n});`;
+
+	magicString.trim()
+		.prepend( importBlock + wrapperStart )
+		.trim()
+		.append( wrapperEnd );
+
+	code = magicString.toString();
+
+	return { code, map: { mappings: '' }, namedExports };
+}

--- a/src/transform.js
+++ b/src/transform.js
@@ -1,10 +1,10 @@
 import acorn from 'acorn';
-import { basename, extname } from 'path';
 import { walk } from 'estree-walker';
 import MagicString from 'magic-string';
 import { attachScopes, makeLegalIdentifier } from 'rollup-pluginutils';
 import { flatten, isReference } from './ast-utils.js';
 import { PREFIX, HELPERS_ID } from './helpers.js';
+import { getName } from './utils.js';
 
 const reserved = 'abstract arguments boolean break byte case catch char class const continue debugger default delete do double else enum eval export extends false final finally float for function goto if implements import in instanceof int interface let long native new null package private protected public return short static super switch synchronized this throw throws transient true try typeof var void volatile while with yield'.split( ' ' );
 var blacklistedExports = { __esModule: true };
@@ -33,13 +33,6 @@ function tryParse ( code, id ) {
 		err.message += ` in ${id}`;
 		throw err;
 	}
-}
-
-function getName ( id ) {
-	const base = basename( id );
-	const ext = extname( base );
-
-	return makeLegalIdentifier( ext.length ? base.slice( 0, -ext.length ) : base );
 }
 
 export default function transform ( code, id, isEntry, ignoreGlobal, customNamedExports, sourceMap ) {

--- a/src/transform.js
+++ b/src/transform.js
@@ -168,6 +168,11 @@ export default function transform ( code, id, isEntry, ignoreGlobal, customNamed
 
 	const importBlock = [ `import * as ${HELPERS_NAME} from '${HELPERS_ID}';` ].concat(
 		sources.map( source => {
+			// import the actual module before the proxy, so that we know
+			// what kind of proxy to build
+			return `import '${source}';`;
+		}),
+		sources.map( source => {
 			const { name, importsDefault } = required[ source ];
 			return `import ${importsDefault ? `${name} from ` : ``}'${PREFIX}${source}';`;
 		})

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,7 @@
+import { basename, extname } from 'path';
+import { makeLegalIdentifier } from 'rollup-pluginutils';
+
+export function getName ( id ) {
+	return makeLegalIdentifier( basename( id, extname( id ) ) );
+}
+

--- a/test/samples/other-transforms/bar.js
+++ b/test/samples/other-transforms/bar.js
@@ -1,0 +1,1 @@
+module.exports = 40;

--- a/test/samples/other-transforms/foo.js
+++ b/test/samples/other-transforms/foo.js
@@ -1,0 +1,3 @@
+var bar = require( './bar.js' );
+
+module.exports = bar + 1;

--- a/test/samples/other-transforms/main.js
+++ b/test/samples/other-transforms/main.js
@@ -1,0 +1,3 @@
+import foo from './foo.js';
+
+assert.equal( foo, 42 );

--- a/test/samples/react-apollo/commonjs-bar.js
+++ b/test/samples/react-apollo/commonjs-bar.js
@@ -1,0 +1,6 @@
+function Bar () {
+	this.x = 42;
+}
+
+exports.__esModule = true;
+exports.default = Bar;

--- a/test/samples/react-apollo/commonjs-foo.js
+++ b/test/samples/react-apollo/commonjs-foo.js
@@ -1,0 +1,4 @@
+var Bar = require( './commonjs-bar' );
+
+exports.__esModule = true;
+exports.Bar = Bar.default;

--- a/test/samples/react-apollo/main.js
+++ b/test/samples/react-apollo/main.js
@@ -1,0 +1,3 @@
+import { Bar } from './commonjs-foo.js';
+
+assert.equal( new Bar().x, 42 );

--- a/test/test.js
+++ b/test/test.js
@@ -379,4 +379,19 @@ describe( 'rollup-plugin-commonjs', () => {
 			plugins: [ commonjs() ]
 		}).then( executeBundle );
 	});
+
+	it( 'respects other plugins', () => {
+		return rollup({
+			entry: 'samples/other-transforms/main.js',
+			plugins: [
+				{
+					transform ( code, id ) {
+						if ( id[0] === '\0' ) return null;
+						return code.replace( '40', '41' );
+					}
+				},
+				commonjs()
+			]
+		}).then( executeBundle );
+	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -5,14 +5,16 @@ const { rollup } = require( 'rollup' );
 const nodeResolve = require( 'rollup-plugin-node-resolve' );
 const commonjs = require( '..' );
 
+require( 'source-map-support' ).install();
+
 process.chdir( __dirname );
 
 function executeBundle ( bundle ) {
-	const generated = bundle.generate({
+	const { code } = bundle.generate({
 		format: 'cjs'
 	});
 
-	const fn = new Function( 'module', 'exports', 'require', 'assert', generated.code );
+	const fn = new Function( 'module', 'exports', 'require', 'assert', code );
 
 	const module = { exports: {} };
 
@@ -70,7 +72,7 @@ describe( 'rollup-plugin-commonjs', () => {
 		});
 	});
 
-	it( 'generates a sourcemap', () => {
+	it.skip( 'generates a sourcemap', () => {
 		return rollup({
 			entry: 'samples/sourcemap/main.js',
 			plugins: [ commonjs({ sourceMap: true }) ]
@@ -367,6 +369,13 @@ describe( 'rollup-plugin-commonjs', () => {
 	it( 'deconflict export name and local variable', () => {
 		return rollup({
 			entry: 'samples/deconflict-export-and-local/main.js',
+			plugins: [ commonjs() ]
+		}).then( executeBundle );
+	});
+
+	it( 'does not remove .default properties', () => {
+		return rollup({
+			entry: 'samples/react-apollo/main.js',
 			plugins: [ commonjs() ]
 		}).then( executeBundle );
 	});

--- a/test/test.js
+++ b/test/test.js
@@ -72,7 +72,7 @@ describe( 'rollup-plugin-commonjs', () => {
 		});
 	});
 
-	it.skip( 'generates a sourcemap', () => {
+	it( 'generates a sourcemap', () => {
 		return rollup({
 			entry: 'samples/sourcemap/main.js',
 			plugins: [ commonjs({ sourceMap: true }) ]

--- a/test/test.js
+++ b/test/test.js
@@ -14,7 +14,15 @@ function executeBundle ( bundle ) {
 		format: 'cjs'
 	});
 
-	const fn = new Function( 'module', 'exports', 'require', 'assert', code );
+	let fn;
+
+	try {
+		fn = new Function( 'module', 'exports', 'require', 'assert', code );
+	} catch ( err ) {
+		// syntax error
+		console.log( code );
+		throw err;
+	}
 
 	const module = { exports: {} };
 


### PR DESCRIPTION
This supersedes #91. Summary:

* Sourcemaps are no longer generated for CommonJS modules (explanation below)
* Transformed modules are smaller, largely because namespaces are no longer needlessly generated
* The default export of a transformed CommonJS module is `module.exports`, or, if `exports.__esModule === true`, `exports.default` (previously it would always use `.default` if it was present)
* If a CommonJS module imports another CommonJS module, `.default` interop *no longer takes place* – this fixes bugs like rollup/rollup#866

I won't lie: the approach here feels a little bit crazy. I think that's just the price of having good (and efficient) interop.

Before the explanation, a couple of comparisons:

## Basic CommonJS importing

### Source

```js
// main.js
var foo = require( './foo' );
module.exports = foo * 2;

// foo.js
module.exports = 21;
```

### Before

```js
'use strict';

function interopDefault(ex) {
  return ex && typeof ex === 'object' && 'default' in ex ? ex['default'] : ex;
}

function createCommonjsModule(fn, module) {
  return module = { exports: {} }, fn(module, module.exports), module.exports;
}

var foo = createCommonjsModule(function (module) {
module.exports = 21;
});

var foo$1 = interopDefault(foo);


var require$$0 = Object.freeze({
  default: foo$1
});

var main = createCommonjsModule(function (module) {
var foo = interopDefault(require$$0);
module.exports = foo * 2;
});

var main$1 = interopDefault(main);

module.exports = main$1;
```

### After

```js
'use strict';

function createCommonjsModule(fn, module) {
  return module = { exports: {} }, fn(module, module.exports), module.exports;
}

var require$$0 = createCommonjsModule(function (module) {
module.exports = 21;
});

var main = createCommonjsModule(function (module) {
var foo = require$$0;
module.exports = foo * 2;
});

module.exports = main;
```

## Inline require statements


### Source

```js
// main.js
module.exports = function () {
  return require( './multiply' )( 2, require( './foo' ) );
};

// multiply.js
module.exports = function ( a, b ) {
  return a * b;
};

// foo.js
module.exports = 1;
```

### Before

```js
'use strict';

function interopDefault(ex) {
  return ex && typeof ex === 'object' && 'default' in ex ? ex['default'] : ex;
}

function createCommonjsModule(fn, module) {
  return module = { exports: {} }, fn(module, module.exports), module.exports;
}

var multiply = createCommonjsModule(function (module) {
module.exports = function ( a, b ) {
  return a * b;
};
});

var multiply$1 = interopDefault(multiply);


var require$$1 = Object.freeze({
  default: multiply$1
});

var foo = createCommonjsModule(function (module) {
module.exports = 1;
});

var foo$1 = interopDefault(foo);


var require$$0 = Object.freeze({
  default: foo$1
});

var main = createCommonjsModule(function (module) {
module.exports = function () {
  return interopDefault(require$$1)( 2, interopDefault(require$$0) );
};
});

var main$1 = interopDefault(main);

module.exports = main$1;
```

### After

```js
'use strict';

function createCommonjsModule(fn, module) {
  return module = { exports: {} }, fn(module, module.exports), module.exports;
}

var require$$1 = createCommonjsModule(function (module) {
module.exports = function ( a, b ) {
  return a * b;
};
});

var require$$0 = createCommonjsModule(function (module) {
module.exports = 1;
});

var main = createCommonjsModule(function (module) {
module.exports = function () {
  return require$$1( 2, require$$0 );
};
});

module.exports = main;
```

## How it works

Basically, when you import a CommonJS module from an ES module, you're no longer importing the module itself but a proxy, which imports the *actual* CommonJS module but with a prefixed ID (`\0commonjs-required:/path/to/cjs-module.js`). The proxy handles the ES <-> CJS interop – deciding whether `module.exports` or `exports.default` should be the default export, and adding named exports – while the module itself (with the prefixed ID) *always* just has a single default export which is `module.exports`. Its dependencies are re-declared as prefixed imports.

Meanwhile, if a module with a prefixed ID (i.e., imported by a proxy or a CommonJS module) *isn't* a CommonJS module, we need a different kind of interop layer, which imports the underlying ES module and exports-as-default *either* its default export (if there is one) *or* the entire namespace. That way, we don't need to reify namespaces for everything that a CommonJS module imports, only ES modules.

An unfortunate side-effect of this is that sourcemaps no longer work for CommonJS modules, because the source code lives in virtual modules, which get excluded. I haven't been able to think of a good solution to this. Honestly, I think it's a small trade-off for more reliable interop and more efficient code, given that sourcemaps are mostly useful when you're debugging your own code.

I think this covers all the bases. @rollup/collaborators and others – would welcome any feedback on this before we commit to this road! Sorry for the rambly and complex explanation.
