### PR TITLE
Don't transform modules with import/export

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -14,6 +14,7 @@ var exportsPattern = /^(?:module\.)?exports(?:\.([a-zA-Z_$][a-zA-Z_$0-9]*))?$/;
 
 var firstpassGlobal = /\b(?:require|module|exports|global)\b/;
 var firstpassNoGlobal = /\b(?:require|module|exports)\b/;
+const importExportDeclaration = /^(?:Import|Export(?:Named|Default))Declaration/;
 
 function deconflict ( identifier, code ) {
 	let i = 1;
@@ -43,6 +44,12 @@ export default function transform ( code, id, isEntry, ignoreGlobal, customNamed
 	if ( customNamedExports ) customNamedExports.forEach( name => namedExports[ name ] = true );
 
 	const ast = tryParse( code, id );
+
+	// if there are top-level import/export declarations, this is ES not CommonJS
+	for ( const node of ast.body ) {
+		if ( importExportDeclaration.test( node.type ) ) return null;
+	}
+
 	const magicString = new MagicString( code );
 
 	let required = {};

--- a/test/form/unambiguous-with-default-export/input.js
+++ b/test/form/unambiguous-with-default-export/input.js
@@ -1,0 +1,3 @@
+require( './foo.js' );
+
+export default {};

--- a/test/form/unambiguous-with-default-export/output.js
+++ b/test/form/unambiguous-with-default-export/output.js
@@ -1,0 +1,3 @@
+require( './foo.js' );
+
+export default {};

--- a/test/form/unambiguous-with-import/input.js
+++ b/test/form/unambiguous-with-import/input.js
@@ -1,0 +1,3 @@
+require( './foo.js' );
+
+import './bar.js';

--- a/test/form/unambiguous-with-import/output.js
+++ b/test/form/unambiguous-with-import/output.js
@@ -1,0 +1,3 @@
+require( './foo.js' );
+
+import './bar.js';

--- a/test/form/unambiguous-with-named-export/input.js
+++ b/test/form/unambiguous-with-named-export/input.js
@@ -1,0 +1,3 @@
+require( './foo.js' );
+
+export {};

--- a/test/form/unambiguous-with-named-export/output.js
+++ b/test/form/unambiguous-with-named-export/output.js
@@ -1,0 +1,3 @@
+require( './foo.js' );
+
+export {};

--- a/test/test.js
+++ b/test/test.js
@@ -39,6 +39,30 @@ function executeBundle ( bundle ) {
 }
 
 describe( 'rollup-plugin-commonjs', () => {
+	describe( 'form', () => {
+		const { transform, options } = commonjs();
+		options({ entry: 'main.js' });
+
+		fs.readdirSync( 'form' ).forEach( dir => {
+			let config;
+
+			try {
+				config = require( `./form/${dir}/_config.js` );
+			} catch ( err ) {
+				config = {};
+			}
+
+			( config.solo ? it.only : it )( dir, () => {
+				const input = fs.readFileSync( `form/${dir}/input.js`, 'utf-8' );
+				const expected = fs.readFileSync( `form/${dir}/output.js`, 'utf-8' );
+
+				return transform( input, 'input.js' ).then( transformed => {
+					assert.equal( transformed ? transformed.code : input, expected );
+				});
+			});
+		});
+	});
+
 	describe( 'function', () => {
 		fs.readdirSync( 'function' ).forEach( dir => {
 			let config;


### PR DESCRIPTION
Even if they contain CJS features like `require`, `global` etc. Ref https://github.com/rollup/rollup-plugin-commonjs/issues/88#issuecomment-243555761