### PR TITLE
fix typeof require === "function" && require

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -3,6 +3,10 @@ export const HELPERS_ID = '\0commonjsHelpers';
 export const HELPERS = `
 export var commonjsGlobal = typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
 
+export function commonjsRequire () {
+	throw new Error('Dynamic requires are not currently supported by rollup-plugin-commonjs');
+}
+
 export function unwrapExports (x) {
 	return x && x.__esModule ? x['default'] : x;
 }

--- a/test/function/typeof-require/foo.js
+++ b/test/function/typeof-require/foo.js
@@ -1,0 +1,5 @@
+if ( typeof require === 'function' && require ) {
+	module.exports = 1;
+} else {
+	module.exports = 2;
+}

--- a/test/function/typeof-require/main.js
+++ b/test/function/typeof-require/main.js
@@ -1,0 +1,3 @@
+import foo from './foo.js';
+
+assert.equal( foo, 1 );


### PR DESCRIPTION
Fixes #77 and #83. Rather than rewriting `typeof require`, this replaces `require` identifiers (other than those used in `require(...)` expressions) with a `commonjsRequire` helper. If it gets called, it'll just throw an error, but in the majority of cases it's not there to get called, it's there for some other runtime check that probably shouldn't be a runtime check.