### PR TITLE
allow custom named exports to work with optimised modules

### DIFF
--- a/test/function/reexports/_config.js
+++ b/test/function/reexports/_config.js
@@ -1,0 +1,9 @@
+const path = require( 'path' );
+
+module.exports = {
+	pluginOptions: {
+		namedExports: {
+			[ path.resolve( __dirname, 'foo.js' ) ]: [ 'named' ]
+		}
+	}
+};

--- a/test/function/reexports/bar.js
+++ b/test/function/reexports/bar.js
@@ -1,0 +1,1 @@
+exports.named = 42;

--- a/test/function/reexports/foo.js
+++ b/test/function/reexports/foo.js
@@ -1,0 +1,1 @@
+module.exports = require( './bar.js' );

--- a/test/function/reexports/main.js
+++ b/test/function/reexports/main.js
@@ -1,0 +1,3 @@
+import { named } from './foo.js';
+
+assert.equal( named, 42 );

--- a/test/test.js
+++ b/test/test.js
@@ -89,7 +89,7 @@ describe( 'rollup-plugin-commonjs', () => {
 			( config.solo ? it.only : it )( dir, () => {
 				return rollup({
 					entry: `function/${dir}/main.js`,
-					plugins: [ commonjs() ]
+					plugins: [ commonjs( config.pluginOptions ) ]
 				}).then( bundle => {
 					const { code } = bundle.generate({ format: 'cjs' });
 					if ( config.show || config.solo ) {


### PR DESCRIPTION
This fixes an issue that prevented us from closing #35, namely that 'optimised' modules (as of version 5) don't respect custom named exports. Tangential relationship, but nice to have caught the bug.