### PR TITLE
Replace use left node indexes when producing default export

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -267,7 +267,7 @@ export default function transform ( code, id, isEntry, ignoreGlobal, customNamed
 
 				if ( flattened.keypath === 'module.exports' ) {
 					hasDefaultExport = true;
-					magicString.overwrite( node.start, right.start, `var ${moduleName} = ` );
+					magicString.overwrite( left.start, left.end, `var ${moduleName}` );
 				} else {
 					const name = match[1];
 					const deconflicted = deconflict( scope, globals, name );

--- a/test/samples/paren-expression/index.js
+++ b/test/samples/paren-expression/index.js
@@ -1,0 +1,1 @@
+module.exports = (42);

--- a/test/test.js
+++ b/test/test.js
@@ -262,6 +262,15 @@ describe( 'rollup-plugin-commonjs', () => {
 			});
 		});
 
+		it( 'can handle parens around right have node while producing default export', () => {
+			return rollup({
+				entry: 'samples/paren-expression/index.js',
+				plugins: [ commonjs() ]
+			}).then( bundle => {
+				assert.equal( executeBundle( bundle ).exports, 42 );
+			});
+		});
+
 		describe( 'typeof transforms', () => {
 			it( 'correct-scoping', () => {
 				return rollup({


### PR DESCRIPTION
Basically you can try to use such file to get error:
```js
module.exports = (42);
```

It is compiled to:
```js
var index = 42);
// etc
```