### PR TITLE
Add failing test for default export IIFE

### DIFF
--- a/test/form/optimised-default-export-function-double-assign/input.js
+++ b/test/form/optimised-default-export-function-double-assign/input.js
@@ -1,0 +1,2 @@
+var bar;
+module.exports = bar = function foo () {};

--- a/test/form/optimised-default-export-function-double-assign/output.js
+++ b/test/form/optimised-default-export-function-double-assign/output.js
@@ -1,0 +1,5 @@
+var bar;
+var input = bar = function foo () {};
+
+export default input;
+export { input as __moduleExports };

--- a/test/form/optimised-default-export-iife/input.js
+++ b/test/form/optimised-default-export-iife/input.js
@@ -1,0 +1,3 @@
+module.exports = (function foo () {
+  return function fooChild() {};
+}());

--- a/test/form/optimised-default-export-iife/output.js
+++ b/test/form/optimised-default-export-iife/output.js
@@ -1,0 +1,6 @@
+var input = (function foo () {
+  return function fooChild() {};
+}());
+
+export default input;
+export { input as __moduleExports };


### PR DESCRIPTION
This plugin does not transform all IIFEs properly (see https://github.com/rollup/rollup-plugin-commonjs/issues/123) This PR adds a failing test which demos a case where parsing fails.  The leading open parenthesis on the IIFE does not show up in the transformed output which causes a parsing error since the closing paren is not matched by a leading one...

The issue is caused by the line: https://github.com/ntilwalli/rollup-plugin-commonjs/blob/v5.0.4/src/transform.js#L270

The leading paren is preserved if the above line is changed to:

```
magicString.overwrite( node.start, right.start - 1, `var ${moduleName} = ` );
```

However doing so causes some other tests to fail on formatting issues.  I'm posting this PR for comment on the best way to approach.
