### PR TITLE
Simplify repository config

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,7 @@
     "source-map": "^0.5.6",
     "source-map-support": "^0.4.2"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/rollup/rollup-plugin-commonjs.git"
-  },
+  "repository": "rollup/rollup-plugin-commonjs",
   "author": "Rich Harris",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Since we're using GitHub we can use [the shorthand syntax](https://docs.npmjs.com/files/package.json#repository).
