### PR TITLE
Fixes Duplicate export 'default'

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -278,6 +278,10 @@ export default function transformCommonjs ( code, id, isEntry, ignoreGlobal, cus
 				const match = exportsPattern.exec( flattened.keypath );
 				if ( !match ) return;
 
+				if ( flattened.keypath === 'module.exports.default' && hasDefaultExport ) {
+					return;
+				}
+
 				if ( flattened.keypath === 'module.exports' ) {
 					hasDefaultExport = true;
 					magicString.overwrite( left.start, left.end, `var ${moduleName}` );

--- a/test/samples/dupplicate-default-export/main.js
+++ b/test/samples/dupplicate-default-export/main.js
@@ -1,0 +1,2 @@
+module.exports = 'first export';
+module.exports.default = 'second ignored export';

--- a/test/test.js
+++ b/test/test.js
@@ -305,6 +305,15 @@ describe( 'rollup-plugin-commonjs', () => {
 			});
 		});
 
+		it( 'ignores dupplicate module.exports.global export', () => {
+			return rollup({
+				entry: 'samples/dupplicate-default-export/main.js',
+				plugins: [ commonjs() ]
+			}).then( executeBundle ).then( ({ exports }) => {
+				assert.equal( exports, 'first export' );
+			});
+		});
+
 		it( 'deconflicts helper name', () => {
 			return rollup({
 				entry: 'samples/deconflict-helpers/main.js',


### PR DESCRIPTION
Some packages (i.e. axios) both export via "module.exports" and "module.exports.default" which triggers the following error in rollup: Duplicate export 'default'. This PR fixes this issue.