### PR TITLE
Fixed issue #168

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -287,7 +287,7 @@ export default function transformCommonjs ( code, id, isEntry, ignoreGlobal, cus
 
 					names.push({ name, deconflicted });
 
-					magicString.overwrite( node.start, right.start, `var ${deconflicted} = ` );
+					magicString.overwrite( node.start, left.end, `var ${deconflicted}` );
 
 					const declaration = name === deconflicted ?
 						`export { ${name} };` :

--- a/src/transform.js
+++ b/src/transform.js
@@ -270,7 +270,7 @@ export default function transformCommonjs ( code, id, isEntry, ignoreGlobal, cus
 
 		ast.body.forEach( node => {
 			if ( node.type === 'ExpressionStatement' && node.expression.type === 'AssignmentExpression' ) {
-				const { left, right } = node.expression;
+				const left = node.expression.left;
 				const flattened = flatten( left );
 
 				if ( !flattened ) return;


### PR DESCRIPTION
When the right side of an export is inside parentheses, the start of the right side ignores the left parenthesis. If we take the left side of the expression, we don't have this problem.