### PR TITLE
prefer existing names for dependencies, over require$$x

### DIFF
--- a/src/ast-utils.js
+++ b/src/ast-utils.js
@@ -31,6 +31,39 @@ export function flatten ( node ) {
 	return { name, keypath: parts.join( '.' ) };
 }
 
+export function extractNames ( node ) {
+	const names = [];
+	extractors[ node.type ]( names, node );
+	return names;
+}
+
+const extractors = {
+	Identifier ( names, node ) {
+		names.push( node.name );
+	},
+
+	ObjectPattern ( names, node ) {
+		node.properties.forEach( prop => {
+			extractors[ prop.value.type ]( names, prop.value );
+		});
+	},
+
+	ArrayPattern ( names, node ) {
+		node.elements.forEach( element => {
+			if ( element ) extractors[ element.type ]( names, element );
+		});
+	},
+
+	RestElement ( names, node ) {
+		extractors[ node.argument.type ]( names, node.argument );
+	},
+
+	AssignmentPattern ( names, node ) {
+		extractors[ node.left.type ]( names, node.left );
+	}
+};
+
+
 export function isTruthy ( node ) {
 	if ( node.type === 'Literal' ) return !!node.value;
 	if ( node.type === 'ParenthesizedExpression' ) return isTruthy( node.expression );

--- a/test/form/ignore-ids-function/output.js
+++ b/test/form/ignore-ids-function/output.js
@@ -1,8 +1,8 @@
 import 'bar';
-import require$$0 from 'commonjs-proxy:bar';
+import bar from 'commonjs-proxy:bar';
 
 var foo = require( 'foo' );
-var bar = require$$0;
+
 
 var input = {
 

--- a/test/form/ignore-ids/output.js
+++ b/test/form/ignore-ids/output.js
@@ -1,8 +1,8 @@
 import 'bar';
-import require$$0 from 'commonjs-proxy:bar';
+import bar from 'commonjs-proxy:bar';
 
 var foo = require( 'foo' );
-var bar = require$$0;
+
 
 var input = {
 


### PR DESCRIPTION
This addresses #176 — common cases like this...

```js
var x = require('x');
```

...will become like this...

```js
import x from 'x';
```

...instead of this:

```js
import require$$0 from 'x';
// ...
var x = require$$0;
```

It involves a bit of extra work, since we need to prevent this from happening in cases where `x` is reassigned (legally in CommonJS but illegally in ES modules), but I reckon it's worth it — the converted code is cleaner.