### PR TITLE
Include a regexp in options documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ export default {
     commonjs({
       // non-CommonJS modules will be ignored, but you can also
       // specifically include/exclude files
-      include: '/node_modules/**',  // Default: undefined
+      include: 'node_modules/**',  // Default: undefined
       exclude: [ 'node_modules/foo/**', 'node_modules/bar/**' ],  // Default: undefined
       // these values can also be regular expressions
       // include: /node_modules/

--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ export default {
     commonjs({
       // non-CommonJS modules will be ignored, but you can also
       // specifically include/exclude files
-      include: 'node_modules/**',  // Default: undefined
+      include: '/node_modules/**',  // Default: undefined
       exclude: [ 'node_modules/foo/**', 'node_modules/bar/**' ],  // Default: undefined
+      // these values can also be regular expressions
+      // include: /node_modules/
 
       // search for files other than .js files (must already
       // be transpiled by a previous plugin!)


### PR DESCRIPTION
From what I can tell, right now you have to dig into the `rollup-pluginutils` source to see that `include`/`exclude` values can be regular expressions. I have a project that is using Lerna (with hoisting) and it might have been my lack of familiarity with `minimatch`, but I was writing an `include` array like this to ensure that every dependency was matched:
```js
commonjs({
  include: ['node_modules/**', '../../node_modules/**', '../**/node_modules/**']
})
```
That could probably be optimized, but it covered all of my bases.

Once I saw that I could just use a regular expression, I switched to that and it looks much cleaner while still matching all files in `node_modules` directories.
```js
commonjs({
  include: /node_modules/
})
```
Maybe there is a better place to document this, but this seemed like the simplest solution.