### PR TITLE
Prefer parent directory over index for module name

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,13 @@
-import { basename, extname } from 'path';
+import { basename, extname, dirname, sep } from 'path';
 import { makeLegalIdentifier } from 'rollup-pluginutils';
 
 export function getName ( id ) {
-	return makeLegalIdentifier( basename( id, extname( id ) ) );
+	const name = makeLegalIdentifier( basename( id, extname( id ) ) );
+	if (name !== 'index') {
+		return name;
+	} else {
+		const segments = dirname( id ).split( sep );
+		return makeLegalIdentifier( segments[segments.length - 1] );
+	}
 }
 

--- a/test/samples/rename-index/invalid-var/index.js
+++ b/test/samples/rename-index/invalid-var/index.js
@@ -1,0 +1,1 @@
+module.exports = 'invalid';

--- a/test/samples/rename-index/main.js
+++ b/test/samples/rename-index/main.js
@@ -1,0 +1,5 @@
+import invalid from './invalid-var';
+import valid from './validVar';
+import other from './other/nonIndex';
+
+console.log(invalid, valid, other);

--- a/test/samples/rename-index/other/nonIndex.js
+++ b/test/samples/rename-index/other/nonIndex.js
@@ -1,0 +1,1 @@
+module.exports = 'not an index file';

--- a/test/samples/rename-index/validVar/index.js
+++ b/test/samples/rename-index/validVar/index.js
@@ -1,0 +1,1 @@
+module.exports = 'valid';

--- a/test/test.js
+++ b/test/test.js
@@ -405,5 +405,19 @@ describe( 'rollup-plugin-commonjs', () => {
 				assert.equal( exports, 'HELLO' );
 			});
 		});
+
+		it( 'prefers to set name using directory for index files', () => {
+			return rollup({
+				entry: 'samples/rename-index/main.js',
+				plugins: [ commonjs() ]
+			})
+			.then( async bundle => {
+				const { code } = await bundle.generate({ format: 'cjs' });
+				assert.equal( code.indexOf( 'var index' ), -1 );
+				assert.notEqual( code.indexOf( 'var invalidVar' ), -1 );
+				assert.notEqual( code.indexOf( 'var validVar' ), -1 );
+				assert.notEqual( code.indexOf( 'var nonIndex' ), -1 );
+			});
+		});
 	});
 });


### PR DESCRIPTION
This is purely an aesthetic request, but one that I think would make reading the output of Rollup much easier.

Currently, when this plugin is determining a module's name [0], it uses the `basename` of the `id` [1] to determine the module's name. If the `id` is `/node_modules/SomePackage/module.js`, we end up with the module name `module`. If the `id` was `/node_modules/SomePackage/index.js`, then we end up with the module name `index`.

The difference between these two is that for the former, we have to explicitly state that we want to import from that file, while for the latter, we only have to provide the package, since `index.js` is the default file to resolve to.

```js
import X from 'SomePackage/module';
import Y from 'SomePackage';
```

Anecdotally, I do the latter a lot more, which means that I end up with a lot of `index` (and deconflicted `index$1`, etc.) variables throughout the bundle. Functionally this is fine, but it makes it difficult to follow when actually reading through the bundle's code and <kbd>Ctrl</kbd>+<kbd>f</kbd> for `index` has a few dozen results.

What this PR does is to check the output of `getName` prior to returning, and if it is `index` (and the user has specified to avoid `index` names), then the name of the parent segment from the directory path is used instead.

```js
// validVar/index.js
module.exports = 'one';

// currently outputs
var index = 'one'

export default index;
export { index as _moduleExports };

// and with this PR becomes
var validVar = 'one'

export default validVar;
export { validVar as _moduleExports };
```
This also takes into account directory names that are invalid as variable names.
```js
// invalid-var/index.js
module.exports = 'one';

// becomes
var invalidVar = 'one'

export default invalidVar;
export { invalidVar as _moduleExports };
```
Currently, this PR doesn't have any tests. I took a look at the current tests and TBH I wasn't exactly sure how I should be testing this. If this is something that you decide to move forward with, I'll obviously add tests, but I could use some guidance on their setup.