### PR TITLE
chore: use shx so rm is cross-platform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-commonjs",
-  "version": "8.0.2",
+  "version": "8.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -405,6 +405,12 @@
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
       }
+    },
+    "es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
+      "dev": true
     },
     "es6-set": {
       "version": "0.1.5",
@@ -1603,6 +1609,17 @@
         "glob": "7.1.2",
         "interpret": "1.0.3",
         "rechoir": "0.6.2"
+      }
+    },
+    "shx": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.2.2.tgz",
+      "integrity": "sha1-CjBNAgsO3xMGrYFXDoDwNG31ijk=",
+      "dev": true,
+      "requires": {
+        "es6-object-assign": "1.1.0",
+        "minimist": "1.2.0",
+        "shelljs": "0.7.8"
       }
     },
     "slice-ansi": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "mocha",
     "pretest": "npm run build",
-    "build": "rm -rf dist/* && rollup -c",
+    "build": "shx rm -rf dist/* && rollup -c",
     "dev": "rollup -c -w",
     "lint": "eslint src/*.js test/*.js",
     "prepublish": "npm run lint && npm test"
@@ -34,6 +34,7 @@
     "rollup-plugin-buble": "^0.15.0",
     "rollup-plugin-node-resolve": "^2.0.0",
     "rollup-watch": "^3.1.0",
+    "shx": "^0.2.2",
     "source-map": "^0.5.6",
     "source-map-support": "^0.4.2"
   },


### PR DESCRIPTION
Wasn't able to run anything on windows because lol windows doesn't have `rm`, replaced it with `shx rm` and now I can work!