### PR TITLE
chore: update rollup to 0.47.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-commonjs",
-  "version": "8.0.2",
+  "version": "8.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1508,13 +1508,10 @@
       }
     },
     "rollup": {
-      "version": "0.40.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.40.2.tgz",
-      "integrity": "sha1-tZyDdzMvgovjiYMZLzNp5QL55Es=",
-      "dev": true,
-      "requires": {
-        "source-map-support": "0.4.15"
-      }
+      "version": "0.47.6",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.47.6.tgz",
+      "integrity": "sha512-bH3eWh7MzbiKTQcHQN7Ievqbs/yY7T+ZcJYboBYkp7BkRlAr2DXHPfiqlvlEH/M95giEBpinHEi/s9CVIgYT6w==",
+      "dev": true
     },
     "rollup-plugin-buble": {
       "version": "0.15.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "locate-character": "^2.0.0",
     "mocha": "^3.0.2",
     "require-relative": "^0.8.7",
-    "rollup": "^0.40.2",
+    "rollup": "^0.47.6",
     "rollup-plugin-buble": "^0.15.0",
     "rollup-plugin-node-resolve": "^2.0.0",
     "rollup-watch": "^3.1.0",


### PR DESCRIPTION
Require a bunch of test case reworking after `bundle.generate()` started returning a Promise. Hopefully I got the formatting right, linter didn't seem to mind at least!