### PR TITLE
Fix duplicate export error (e.g. when importing Cheerio)

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -374,10 +374,12 @@ export default function transformCommonjs ( code, id, isEntry, ignoreGlobal, ign
 						`export { ${name} };` :
 						`export { ${deconflicted} as ${name} };`;
 
-					namedExportDeclarations.push({
-						str: declaration,
-						name
-					});
+					if ( name !== 'default' ) {
+						namedExportDeclarations.push({
+							str: declaration,
+							name
+						});
+					}
 
 					defaultExportPropertyAssignments.push( `${moduleName}.${name} = ${deconflicted};` );
 				}

--- a/test/function/duplicate-default-exports-c/exports.js
+++ b/test/function/duplicate-default-exports-c/exports.js
@@ -1,0 +1,6 @@
+exports.Foo = 1;
+exports.var = 'VAR';
+exports.default = {
+	Foo: 2,
+	default: 3
+};

--- a/test/function/duplicate-default-exports-c/main.js
+++ b/test/function/duplicate-default-exports-c/main.js
@@ -1,0 +1,11 @@
+import E from './exports.js';
+import { Foo } from './exports.js';
+import { var as Var } from './exports.js';
+
+assert.strictEqual( E.Foo, 1 );
+assert.strictEqual( E.var, 'VAR' );
+assert.deepEqual( E.default, { Foo: 2, default:  3 });
+assert.strictEqual( E.default.Foo, 2 );
+assert.strictEqual( E.default.default, 3 );
+assert.strictEqual( Foo, 1 );
+assert.strictEqual( Var, 'VAR' );


### PR DESCRIPTION
Fixes https://github.com/rollup/rollup/issues/1637

I've tried to follow @kzc's [patch and test cases](https://github.com/rollup/rollup/issues/1637#issuecomment-330338099) as closely as I could, but please let me know if I need to make any changes.

Thanks,
Caleb