### PR TITLE
add esModulesWithoutDefaultExport check

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -171,14 +171,14 @@ export default function commonjs ( options = {} ) {
 			return entryModuleIdPromise.then( () => {
 				const {isEsModule, hasDefaultExport, ast} = checkEsModule( code, id );
 				if ( isEsModule ) {
-				  if ( !hasDefaultExport )
-				    esModulesWithoutDefaultExport.push( id );
+					if ( !hasDefaultExport )
+						esModulesWithoutDefaultExport.push( id );
 					return;
 				}
 
+				// it is not an ES module but not a commonjs module, too.
 				if ( !checkFirstpass( code, ignoreGlobal ) ) {
-				  if ( !hasDefaultExport )
-				    esModulesWithoutDefaultExport.push( id );
+					esModulesWithoutDefaultExport.push( id );
 					return;
 				}
 

--- a/src/index.js
+++ b/src/index.js
@@ -169,10 +169,14 @@ export default function commonjs ( options = {} ) {
 			if ( extensions.indexOf( extname( id ) ) === -1 ) return null;
 
 			return entryModuleIdPromise.then( () => {
-				if ( !checkFirstpass( code, ignoreGlobal ) ) return;
-
 				const {isEsModule, hasDefaultExport, ast} = checkEsModule( code, id );
 				if ( isEsModule ) {
+				  if ( !hasDefaultExport )
+				    esModulesWithoutDefaultExport.push( id );
+					return;
+				}
+
+				if ( !checkFirstpass( code, ignoreGlobal ) ) {
 				  if ( !hasDefaultExport )
 				    esModulesWithoutDefaultExport.push( id );
 					return;

--- a/src/transform.js
+++ b/src/transform.js
@@ -46,8 +46,18 @@ export default function transformCommonjs ( code, id, isEntry, ignoreGlobal, ign
 	const ast = tryParse( code, id );
 
 	// if there are top-level import/export declarations, this is ES not CommonJS
-	for ( const node of ast.body ) {
-		if ( importExportDeclaration.test( node.type ) ) return null;
+	{
+		let hasDefaultExport = false;
+		let isEsModule = false;
+		for ( const node of ast.body ) {
+			if ( node.type === 'ExportDefaultDeclaration' )
+				hasDefaultExport = true;
+			if ( importExportDeclaration.test( node.type ) )
+				isEsModule = true;
+		}
+		if (isEsModule) {
+			return { code, map: sourceMap, isEsModule, hasDefaultExport };
+		}
 	}
 
 	const magicString = new MagicString( code );

--- a/test/samples/es-modules-without-default-export/main.js
+++ b/test/samples/es-modules-without-default-export/main.js
@@ -1,0 +1,3 @@
+const { a } = require('./other.js');
+
+assert.equal( a, 1 );

--- a/test/samples/es-modules-without-default-export/other.js
+++ b/test/samples/es-modules-without-default-export/other.js
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/test/test.js
+++ b/test/test.js
@@ -94,7 +94,7 @@ describe( 'rollup-plugin-commonjs', () => {
 			( config.solo ? it.only : it )( dir, async () => {
 				const options = Object.assign({
 					input: `function/${dir}/main.js`,
-					plugins: [ commonjs( config.pluginOptions ) ]
+					plugins: [ commonjs( config.pluginOptions ) ],
 				}, config.options || {} );
 
 				const bundle = await rollup( options );
@@ -431,6 +431,23 @@ describe( 'rollup-plugin-commonjs', () => {
 			const window = {};
 			await executeBundle( bundle, { context: { window } } );
 			assert.notEqual( window.b.default, undefined );
+		});
+
+		it( 'does not warn even if the ES module not export "default"', async () => {
+			const warns = [];
+			await rollup({
+				input: 'samples/es-modules-without-default-export/main.js',
+				plugins: [ commonjs() ],
+				onwarn: (warn) => warns.push( warn )
+			});
+			assert.equal( warns.length, 0 );
+
+			await rollup({
+				input: 'function/bare-import/bar.js',
+				plugins: [ commonjs() ],
+				onwarn: (warn) => warns.push( warn )
+			});
+			assert.equal( warns.length, 0 );
 		});
 	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -94,7 +94,7 @@ describe( 'rollup-plugin-commonjs', () => {
 			( config.solo ? it.only : it )( dir, async () => {
 				const options = Object.assign({
 					input: `function/${dir}/main.js`,
-					plugins: [ commonjs( config.pluginOptions ) ],
+					plugins: [ commonjs( config.pluginOptions ) ]
 				}, config.options || {} );
 
 				const bundle = await rollup( options );


### PR DESCRIPTION
#206

This PR find `ExportDefaultDeclaration` from AST and switches commonjs-proxy code when "export default" can not be found.

rollup will not output warning.