### PR TITLE
Enable github install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ env:
   global:
     - BUILD_TIMEOUT=10000
 install: npm install
+before_install:
+  - if [[ $TRAVIS_NODE_VERSION -lt 7 ]]; then npm install --global npm@4; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
+  - IF %nodejs_version% LSS 7 npm -g install npm@4
   - npm install
 
 build: off

--- a/package.json
+++ b/package.json
@@ -6,12 +6,14 @@
   "module": "dist/rollup-plugin-commonjs.es.js",
   "jsnext:main": "dist/rollup-plugin-commonjs.es.js",
   "scripts": {
-    "test": "mocha",
+    "test": "npm run test:only",
+    "test:only": "mocha",
     "pretest": "npm run build",
     "build": "shx rm -rf dist/* && rollup -c",
     "dev": "rollup -c -w",
     "lint": "eslint src/*.js test/*.js",
-    "prepublish": "npm run lint && npm test"
+    "prepublishOnly": "npm run lint && npm run test:only",
+    "prepare": "npm run build"
   },
   "files": [
     "src",


### PR DESCRIPTION
This will change the build process to use a "prepare" script similarly to what has been done for rollup itself. This should enable direct installs from e.g. a github URL.