### PR TITLE
Always wrap in options.external

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -124,10 +124,10 @@ export default function commonjs ( options = {} ) {
 				})
 				.filter( Boolean );
 
-			const isExternal = options.external ?
-				Array.isArray( options.external ) ? id => ~options.external.indexOf( id ) :
-					options.external :
-				() => false;
+			const isExternal = id => options.external ?
+				Array.isArray( options.external ) ? ~options.external.indexOf( id ) :
+					options.external(id) :
+				false;
 
 			resolvers.unshift( id => isExternal( id ) ? false : null );
 


### PR DESCRIPTION
It's safer to check `options.external` immediately before usage, since e. g. later plugins might change it. Closes #263.