### PR TITLE
 Add back support for named exports from module.exports objects 

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -359,10 +359,6 @@ export function transformCommonjs ( code, id, isEntry, ignoreGlobal, ignoreRequi
 
 		wrapperStart = `var ${moduleName} = ${HELPERS_NAME}.createCommonjsModule(function (${args}) {\n`;
 		wrapperEnd = `\n});`;
-
-		Object.keys( namedExports )
-			.filter( key => !blacklist[ key ] )
-			.forEach( addExport );
 	} else {
 		const names = [];
 
@@ -396,6 +392,7 @@ export function transformCommonjs ( code, id, isEntry, ignoreGlobal, ignoreRequi
 							str: declaration,
 							name
 						});
+						delete namedExports[name];
 					}
 
 					defaultExportPropertyAssignments.push( `${moduleName}.${name} = ${deconflicted};` );
@@ -409,6 +406,9 @@ export function transformCommonjs ( code, id, isEntry, ignoreGlobal, ignoreRequi
 			}\n};`;
 		}
 	}
+	Object.keys( namedExports )
+		.filter( key => !blacklist[ key ] )
+		.forEach( addExport );
 
 	const defaultExport = /__esModule/.test( code ) ?
 		`export default ${HELPERS_NAME}.unwrapExports(${moduleName});` :

--- a/test/test.js
+++ b/test/test.js
@@ -252,6 +252,20 @@ describe( 'rollup-plugin-commonjs', () => {
 			assert.equal( (await executeBundle( bundle )).exports, 42 );
 		});
 
+		it( 'identifies named exports from object literals', async () => {
+			const bundle = await rollup({
+				input: 'samples/named-exports-from-object-literal/main.js',
+				plugins: [ commonjs() ]
+			});
+
+			const { code } = await bundle.generate({
+				format: 'cjs'
+			});
+
+			const fn = new Function ( 'module', 'assert', code );
+			fn( {}, assert );
+		});
+
 		it( 'can ignore references to `global`', async () => {
 			const bundle = await rollup({
 				input: 'samples/ignore-global/main.js',


### PR DESCRIPTION
This was broken in 8a3e99e. Closes #267.