### PR TITLE
Add support for experimentalCodeSplitting from Rollup 0.55.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1435,9 +1435,9 @@
       }
     },
     "rollup": {
-      "version": "0.50.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.50.0.tgz",
-      "integrity": "sha512-7RqCBQ9iwsOBPkjYgoIaeUij606mSkDMExP0NT7QDI3bqkHYQHrQ83uoNIXwPcQm/vP2VbsUz3kiyZZ1qPlLTQ==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.55.0.tgz",
+      "integrity": "sha512-uCwDXz2qHQ0XsPekrLIeIEORSF32Zfk1H057ENgb+sj84m10pWaG2YGQSvF8kvyf0WLcrzk2TzYuC/+iZP4hyA==",
       "dev": true
     },
     "rollup-plugin-buble": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "locate-character": "^2.0.1",
     "mocha": "^4.0.1",
     "require-relative": "^0.8.7",
-    "rollup": "^0.50.0",
+    "rollup": "^0.55.0",
     "rollup-plugin-buble": "^0.16.0",
     "rollup-plugin-node-resolve": "^3.0.0",
     "shx": "^0.2.2",

--- a/src/index.js
+++ b/src/index.js
@@ -67,8 +67,8 @@ export default function commonjs ( options = {} ) {
 		Array.isArray( options.ignore ) ? id => ~options.ignore.indexOf( id ) :
 			() => false;
 
-	let entryModuleIdPromise = null;
-	let entryModuleId = null;
+	let entryModuleIdsPromise = null;
+	const entryModuleIds = [];
 
 	function resolveId ( importee, importer ) {
 		if ( importee === HELPERS_ID ) return importee;
@@ -133,9 +133,14 @@ export default function commonjs ( options = {} ) {
 
 			resolveUsingOtherResolvers = first( resolvers );
 
-			entryModuleIdPromise = resolveId( options.input || options.entry ).then( resolved => {
-				entryModuleId = resolved;
-			});
+			const entryModules = [].concat( options.input || options.entry );
+			entryModuleIdsPromise = Promise.all(
+				entryModules.map( entry =>
+					resolveId( entry ).then( resolved => {
+						entryModuleIds.push( resolved );
+					})
+				)
+			);
 		},
 
 		resolveId,
@@ -168,7 +173,7 @@ export default function commonjs ( options = {} ) {
 			if ( !filter( id ) ) return null;
 			if ( extensions.indexOf( extname( id ) ) === -1 ) return null;
 
-			return entryModuleIdPromise.then( () => {
+			return entryModuleIdsPromise.then( () => {
 				const {isEsModule, hasDefaultExport, ast} = checkEsModule( code, id );
 				if ( isEsModule ) {
 					if ( !hasDefaultExport )
@@ -182,7 +187,7 @@ export default function commonjs ( options = {} ) {
 					return;
 				}
 
-				const transformed = transformCommonjs( code, id, id === entryModuleId, ignoreGlobal, ignoreRequire, customNamedExports[ id ], sourceMap, allowDynamicRequire, ast );
+				const transformed = transformCommonjs( code, id, entryModuleIds.indexOf(id) !== -1, ignoreGlobal, ignoreRequire, customNamedExports[ id ], sourceMap, allowDynamicRequire, ast );
 				if ( !transformed ) return;
 
 				commonjsModules.set( id, true );

--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,6 @@ export default function commonjs ( options = {} ) {
 			() => false;
 
 	let entryModuleIdsPromise = null;
-	const entryModuleIds = [];
 
 	function resolveId ( importee, importer ) {
 		if ( importee === HELPERS_ID ) return importee;
@@ -135,11 +134,7 @@ export default function commonjs ( options = {} ) {
 
 			const entryModules = [].concat( options.input || options.entry );
 			entryModuleIdsPromise = Promise.all(
-				entryModules.map( entry =>
-					resolveId( entry ).then( resolved => {
-						entryModuleIds.push( resolved );
-					})
-				)
+				entryModules.map( entry => resolveId( entry ))
 			);
 		},
 
@@ -173,7 +168,7 @@ export default function commonjs ( options = {} ) {
 			if ( !filter( id ) ) return null;
 			if ( extensions.indexOf( extname( id ) ) === -1 ) return null;
 
-			return entryModuleIdsPromise.then( () => {
+			return entryModuleIdsPromise.then( (entryModuleIds) => {
 				const {isEsModule, hasDefaultExport, ast} = checkEsModule( code, id );
 				if ( isEsModule ) {
 					if ( !hasDefaultExport )

--- a/test/samples/multiple-entry-points/2.js
+++ b/test/samples/multiple-entry-points/2.js
@@ -1,0 +1,4 @@
+function second () {
+	console.log('second');
+}
+exports.second = second;

--- a/test/samples/multiple-entry-points/3.js
+++ b/test/samples/multiple-entry-points/3.js
@@ -1,0 +1,5 @@
+function third () {
+	console.log('third');
+}
+
+exports.third = third;

--- a/test/samples/multiple-entry-points/4.js
+++ b/test/samples/multiple-entry-points/4.js
@@ -1,0 +1,3 @@
+export function fourth () {
+	console.log('fourth');
+}

--- a/test/samples/multiple-entry-points/b.js
+++ b/test/samples/multiple-entry-points/b.js
@@ -1,0 +1,5 @@
+import { second } from './2';
+import { third } from './3';
+
+second();
+third();

--- a/test/samples/multiple-entry-points/c.js
+++ b/test/samples/multiple-entry-points/c.js
@@ -1,0 +1,7 @@
+import { second } from './2';
+import { third } from './3';
+import { fourth } from './4';
+
+second();
+third();
+fourth();

--- a/test/test.js
+++ b/test/test.js
@@ -130,7 +130,6 @@ describe( 'rollup-plugin-commonjs', () => {
 
 			let generatedLoc = locator( '42' );
 			let loc = smc.originalPositionFor( generatedLoc ); // 42
-			console.log(JSON.stringify(generated, null, 2));
 			assert.equal( loc.source, 'foo.js' );
 			assert.equal( loc.line, 1 );
 			assert.equal( loc.column, 15 );
@@ -140,6 +139,25 @@ describe( 'rollup-plugin-commonjs', () => {
 			assert.equal( loc.source, 'main.js' );
 			assert.equal( loc.line, 2 );
 			assert.equal( loc.column, 8 );
+		});
+
+		it( 'supports multiple entry points for experimentalCodeSplitting', async () => {
+			const bundle = await rollup({
+				input: [
+					'samples/multiple-entry-points/b.js',
+					'samples/multiple-entry-points/c.js'
+				],
+				experimentalCodeSplitting: true,
+				plugins: [ commonjs() ]
+			});
+
+			const generated = await bundle.generate({
+				format: 'cjs',
+			});
+
+			assert.equal(Object.keys(generated).length, 3);
+			assert.equal(generated.hasOwnProperty('./b.js'), true);
+			assert.equal(generated.hasOwnProperty('./c.js'), true);
 		});
 
 		it( 'handles references to `global`', async () => {

--- a/test/test.js
+++ b/test/test.js
@@ -130,13 +130,14 @@ describe( 'rollup-plugin-commonjs', () => {
 
 			let generatedLoc = locator( '42' );
 			let loc = smc.originalPositionFor( generatedLoc ); // 42
-			assert.equal( loc.source, 'samples/sourcemap/foo.js' );
+			console.log(JSON.stringify(generated, null, 2));
+			assert.equal( loc.source, 'foo.js' );
 			assert.equal( loc.line, 1 );
 			assert.equal( loc.column, 15 );
 
 			generatedLoc = locator( 'log' );
 			loc = smc.originalPositionFor( generatedLoc ); // log
-			assert.equal( loc.source, 'samples/sourcemap/main.js' );
+			assert.equal( loc.source, 'main.js' );
 			assert.equal( loc.line, 2 );
 			assert.equal( loc.column, 8 );
 		});


### PR DESCRIPTION
This pull request is to close issue #282. The code update includes changes to allow for an array of file paths as well as a single string for `input`/`entry`.  I have also added tests to ensure we have coverage.

As part of this PR I had to upgrade the project's rollup dependency to 0.55. It appears that in doing so a test was failing for sourcemap paths.  If a `sourcemapFile` is supplied then the internal sourcemap paths should be relative.