### PR TITLE
Use parse method from transform context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
     "acorn": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
+      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+      "dev": true
     },
     "acorn-jsx": {
       "version": "3.0.1",
@@ -1435,9 +1436,9 @@
       }
     },
     "rollup": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.55.0.tgz",
-      "integrity": "sha512-uCwDXz2qHQ0XsPekrLIeIEORSF32Zfk1H057ENgb+sj84m10pWaG2YGQSvF8kvyf0WLcrzk2TzYuC/+iZP4hyA==",
+      "version": "0.56.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.56.3.tgz",
+      "integrity": "sha512-/iH4RfioboHgBjo7TbQcdMad/ifVGY/ToOB1AsW7oZHUhfhm+low6QlrImUSaJO1JqklOpWEKlD+b3MZYLuptA==",
       "dev": true
     },
     "rollup-plugin-buble": {
@@ -1595,15 +1596,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -1612,6 +1604,15 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "locate-character": "^2.0.1",
     "mocha": "^4.0.1",
     "require-relative": "^0.8.7",
-    "rollup": "^0.55.0",
+    "rollup": "^0.56.3",
     "rollup-plugin-buble": "^0.16.0",
     "rollup-plugin-node-resolve": "^3.0.0",
     "shx": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
     "README.md"
   ],
   "dependencies": {
-    "acorn": "^5.2.1",
     "estree-walker": "^0.5.0",
     "magic-string": "^0.22.4",
     "resolve": "^1.4.0",
     "rollup-pluginutils": "^2.0.1"
   },
   "devDependencies": {
+    "acorn": "^5.2.1",
     "eslint": "^4.8.0",
     "locate-character": "^2.0.1",
     "mocha": "^4.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -169,7 +169,7 @@ export default function commonjs ( options = {} ) {
 			if ( extensions.indexOf( extname( id ) ) === -1 ) return null;
 
 			return entryModuleIdsPromise.then( (entryModuleIds) => {
-				const {isEsModule, hasDefaultExport, ast} = checkEsModule( code, id );
+				const {isEsModule, hasDefaultExport, ast} = checkEsModule( this.parse, code, id );
 				if ( isEsModule ) {
 					if ( !hasDefaultExport )
 						esModulesWithoutDefaultExport.push( id );
@@ -182,7 +182,7 @@ export default function commonjs ( options = {} ) {
 					return;
 				}
 
-				const transformed = transformCommonjs( code, id, entryModuleIds.indexOf(id) !== -1, ignoreGlobal, ignoreRequire, customNamedExports[ id ], sourceMap, allowDynamicRequire, ast );
+				const transformed = transformCommonjs( this.parse, code, id, entryModuleIds.indexOf(id) !== -1, ignoreGlobal, ignoreRequire, customNamedExports[ id ], sourceMap, allowDynamicRequire, ast );
 				if ( !transformed ) return;
 
 				commonjsModules.set( id, true );

--- a/src/transform.js
+++ b/src/transform.js
@@ -27,11 +27,7 @@ function deconflict ( scope, globals, identifier ) {
 
 function tryParse ( parse, code, id ) {
 	try {
-		return parse( code, {
-			ecmaVersion: 8,
-			sourceType: 'module',
-			allowReturnOutsideFunction: true
-		});
+		return parse( code, { allowReturnOutsideFunction: true });
 	} catch ( err ) {
 		err.message += ` in ${id}`;
 		throw err;

--- a/src/transform.js
+++ b/src/transform.js
@@ -1,4 +1,3 @@
-import acorn from 'acorn';
 import { walk } from 'estree-walker';
 import MagicString from 'magic-string';
 import { attachScopes, makeLegalIdentifier } from 'rollup-pluginutils';
@@ -26,9 +25,9 @@ function deconflict ( scope, globals, identifier ) {
 	return deconflicted;
 }
 
-function tryParse ( code, id ) {
+function tryParse ( parse, code, id ) {
 	try {
-		return acorn.parse( code, {
+		return parse( code, {
 			ecmaVersion: 8,
 			sourceType: 'module',
 			allowReturnOutsideFunction: true
@@ -44,8 +43,8 @@ export function checkFirstpass (code, ignoreGlobal) {
 	return firstpass.test(code);
 }
 
-export function checkEsModule (code, id) {
-	const ast = tryParse(code, id);
+export function checkEsModule ( parse, code, id ) {
+	const ast = tryParse( parse, code, id );
 
 	// if there are top-level import/export declarations, this is ES not CommonJS
 	let hasDefaultExport = false;
@@ -60,8 +59,8 @@ export function checkEsModule (code, id) {
 	return { isEsModule, hasDefaultExport, ast };
 }
 
-export function transformCommonjs ( code, id, isEntry, ignoreGlobal, ignoreRequire, customNamedExports, sourceMap, allowDynamicRequire, astCache ) {
-	const ast = astCache || tryParse( code, id );
+export function transformCommonjs ( parse, code, id, isEntry, ignoreGlobal, ignoreRequire, customNamedExports, sourceMap, allowDynamicRequire, astCache ) {
+	const ast = astCache || tryParse( parse, code, id );
 
 	const magicString = new MagicString( code );
 

--- a/test/test.js
+++ b/test/test.js
@@ -57,7 +57,11 @@ async function executeBundle ( bundle, { context, exports } = {} ) {
 }
 
 const transformContext = {
-	parse: acorn.parse
+	parse: ( input, options ) =>
+		acorn.parse( input, Object.assign( {
+			ecmaVersion: 9,
+			sourceType: 'module',
+		}, options ) )
 };
 
 describe( 'rollup-plugin-commonjs', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,4 @@
+const acorn = require( 'acorn' );
 const path = require( 'path' );
 const fs = require( 'fs' );
 const assert = require( 'assert' );
@@ -55,6 +56,10 @@ async function executeBundle ( bundle, { context, exports } = {} ) {
 	return execute( code, context );
 }
 
+const transformContext = {
+	parse: acorn.parse
+};
+
 describe( 'rollup-plugin-commonjs', () => {
 	describe( 'form', () => {
 		fs.readdirSync( 'form' ).forEach( dir => {
@@ -73,7 +78,7 @@ describe( 'rollup-plugin-commonjs', () => {
 				const input = fs.readFileSync( `form/${dir}/input.js`, 'utf-8' );
 				const expected = fs.readFileSync( `form/${dir}/output.js`, 'utf-8' ).trim();
 
-				return transform( input, 'input.js' ).then( transformed => {
+				return transform.call( transformContext, input, 'input.js' ).then( transformed => {
 					const actual = ( transformed ? transformed.code : input ).trim().replace( /\0/g, '' );
 					assert.equal( actual, expected );
 				});


### PR DESCRIPTION
This depends on https://github.com/rollup/rollup/pull/1945. It removes acorn as a dependency (though it's still a dev dependency for the tests) and uses the `parse` method that is exposed via the `transform` context instead.

fixes #275 (by providing the `acornInjectPlugins` option to rollup)
(maybe others?)
closes #237

TODO:

- [x] change `rollup` version to `0.56.0` when it has been published