### PR TITLE
Create an error with a code frame when parsing fails

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -187,6 +187,8 @@ export default function commonjs ( options = {} ) {
 
 				commonjsModules.set( id, true );
 				return transformed;
+			}).catch(err => {
+				this.error(err, err.loc);
 			});
 		}
 	};

--- a/test/samples/invalid-syntax/main.js
+++ b/test/samples/invalid-syntax/main.js
@@ -1,0 +1,1 @@
+export const foo = 2,

--- a/test/test.js
+++ b/test/test.js
@@ -482,5 +482,16 @@ describe( 'rollup-plugin-commonjs', () => {
 			});
 			assert.equal( warns.length, 0 );
 		});
+
+		it( 'creates an error with a code frame when parsing fails', async () => {
+			try {
+				await rollup({
+					input: 'samples/invalid-syntax/main.js',
+					plugins: [ commonjs() ]
+				});
+			} catch (error) {
+				assert.equal( error.frame, '1: export const foo = 2,\n                        ^' );
+			}
+		});
 	});
 });


### PR DESCRIPTION
By calling `this.error` in `transform` instead of throwing the error directly (in `tryParse`) rollup will augment the error and add a code frame based on the given location before throwing it.