### PR TITLE
Fix for Rollup 0.58

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "locate-character": "^2.0.5",
     "mocha": "^5.0.1",
     "require-relative": "^0.8.7",
-    "rollup": "^0.58.0",
+    "rollup": "^0.57.0",
     "rollup-plugin-buble": "^0.19.2",
     "rollup-plugin-node-resolve": "^3.0.3",
     "shx": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "locate-character": "^2.0.5",
     "mocha": "^5.0.1",
     "require-relative": "^0.8.7",
-    "rollup": "^0.56.4",
+    "rollup": "^0.58.0",
     "rollup-plugin-buble": "^0.19.2",
     "rollup-plugin-node-resolve": "^3.0.3",
     "shx": "^0.2.2",

--- a/src/index.js
+++ b/src/index.js
@@ -219,7 +219,7 @@ export default function commonjs ( options = {} ) {
 				this.error(err, err.loc);
 			});
 
-			setIsCjsPromise(id, transformPromise.then( transformed => transformed ? true : false ));
+			setIsCjsPromise(id, transformPromise.then( transformed => transformed ? true : false, err => true ));
 
 			return transformPromise;
 		}

--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,7 @@ export default function commonjs ( options = {} ) {
 	let resolveUsingOtherResolvers;
 
 	const isCjsPromises = Object.create(null);
-	function getIsCjsTransformPromise ( id ) {
+	function getIsCjsPromise ( id ) {
 		let isCjsPromise = isCjsPromises[id];
 		if (isCjsPromise)
 			return isCjsPromise.promise;
@@ -178,9 +178,9 @@ export default function commonjs ( options = {} ) {
 				const actualId = id.slice( PREFIX.length );
 				const name = getName( actualId );
 
-				return getIsCjsTransformPromise( actualId )
-				.then( isCjsTransform => {
-					if ( isCjsTransform )
+				return getIsCjsPromise( actualId )
+				.then( isCjs => {
+					if ( isCjs )
 						return `import { __moduleExports } from ${JSON.stringify( actualId )}; export default __moduleExports;`;
 					else if (esModulesWithoutDefaultExport.indexOf(actualId) !== -1)
 						return `import * as ${name} from ${JSON.stringify( actualId )}; export default ${name};`;

--- a/test/test.js
+++ b/test/test.js
@@ -165,8 +165,8 @@ describe( 'rollup-plugin-commonjs', () => {
 			});
 
 			assert.equal(Object.keys(generated).length, 3);
-			assert.equal(generated.hasOwnProperty('b.js'), true);
-			assert.equal(generated.hasOwnProperty('c.js'), true);
+			assert.equal(generated.hasOwnProperty('./b.js'), true);
+			assert.equal(generated.hasOwnProperty('./c.js'), true);
 		});
 
 		it( 'handles references to `global`', async () => {

--- a/test/test.js
+++ b/test/test.js
@@ -165,8 +165,8 @@ describe( 'rollup-plugin-commonjs', () => {
 			});
 
 			assert.equal(Object.keys(generated).length, 3);
-			assert.equal(generated.hasOwnProperty('./b.js'), true);
-			assert.equal(generated.hasOwnProperty('./c.js'), true);
+			assert.equal(generated.hasOwnProperty('b.js'), true);
+			assert.equal(generated.hasOwnProperty('c.js'), true);
 		});
 
 		it( 'handles references to `global`', async () => {


### PR DESCRIPTION
The latest Rollup runs the load and transform hooks of plugins in parallel, as a result, some assumptions of ordering in this plugin were breaking, causing https://github.com/rollup/rollup/issues/2159 and likely https://github.com/rollup/rollup/issues/2130 as well.

This restores the ordering guarantees within the plugin itself.