### PR TITLE
Update travis node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 sudo: false
 language: node_js
 node_js:
-  - "node"
+  - "4"
+  - "6"
+  - "8"
+  - "10"
 env:
   global:
     - BUILD_TIMEOUT=10000


### PR DESCRIPTION
I'm in the process of checking why the Rollup builds are failing in NodeJS v6 and v4 only, and if it is related to a regression here, and it would help to have these checked here.