### PR TITLE
Fix Rollup build regression

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -114,7 +114,7 @@ export default function commonjs ( options = {} ) {
 	function setIsCjsPromise ( id, promise ) {
 		const isCjsPromise = isCjsPromises[id];
 		if (isCjsPromise) {
-			if (!isCjsPromise.resolve) {
+			if (isCjsPromise.resolve) {
 				isCjsPromise.resolve(promise);
 				isCjsPromise.resolve = undefined;
 			}

--- a/src/index.js
+++ b/src/index.js
@@ -113,10 +113,15 @@ export default function commonjs ( options = {} ) {
 	}
 	function setIsCjsPromise ( id, promise ) {
 		const isCjsPromise = isCjsPromises[id];
-		if (isCjsPromise)
-			isCjsPromise.resolve(promise);
-		else
+		if (isCjsPromise) {
+			if (!isCjsPromise.resolve) {
+				isCjsPromise.resolve(promise);
+				isCjsPromise.resolve = undefined;
+			}
+		}
+		else {
 			isCjsPromises[id] = { promise: promise, resolve: undefined };
+		}
 	}
 
 	return {

--- a/test/test.js
+++ b/test/test.js
@@ -238,6 +238,32 @@ describe( 'rollup-plugin-commonjs', () => {
 			assert.equal( module.exports, 'foobar', generated.code );
 		});
 
+		it( 'handles successive builds', async () => {
+			const plugin = commonjs()
+			let bundle = await rollup({
+				input: 'samples/corejs/literal-with-default.js',
+				plugins: [ plugin ]
+			});
+			await bundle.generate({
+				format: 'cjs'
+			});
+
+			bundle = await rollup({
+				input: 'samples/corejs/literal-with-default.js',
+				plugins: [ plugin ]
+			});
+			const generated = await bundle.generate({
+				format: 'cjs'
+			});
+
+			const module = { exports: {} };
+
+			const fn = new Function ( 'module', 'exports', generated.code );
+			fn( module, module.exports );
+
+			assert.equal( module.exports, 'foobar', generated.code );
+		});
+
 		it( 'allows named exports to be added explicitly via config', async () => {
 			const bundle = await rollup({
 				input: 'samples/custom-named-exports/main.js',


### PR DESCRIPTION
This handles the already-cached case with a test, as was breaking the Rollup build.