### PR TITLE
Allow chunks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -159,8 +159,13 @@ export default function commonjs ( options = {} ) {
 			resolvers.unshift( id => isExternal( id ) ? false : null );
 
 			resolveUsingOtherResolvers = first( resolvers );
-
-			const entryModules = [].concat( options.input || options.entry );
+			
+			const input = options.input || options.entry || '';
+			const entryModules = Array.isArray(input) ?
+				input :
+				typeof input === 'string' ?
+				[input] : 
+				Object.values(input);
 			entryModuleIdsPromise = Promise.all(
 				entryModules.map( entry => resolveId( entry ))
 			);


### PR DESCRIPTION
It's needed by "chunks" mode https://github.com/rollup/rollup/pull/2084#issuecomment-393440509
chunks options allow objects as input:

it solved this issue:
```
[!] TypeError: str.slice is not a function
TypeError: str.slice is not a function
    at startsWith (/home/caub/dev/color-wheel/node_modules/rollup-plugin-commonjs/src/index.js:37:13)
```