### PR TITLE
Add "location" and "process" to reserved words

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -5,7 +5,7 @@ import { extractNames, flatten, isReference, isTruthy, isFalsy } from './ast-uti
 import { PREFIX, HELPERS_ID } from './helpers.js';
 import { getName } from './utils.js';
 
-const reserved = 'abstract arguments boolean break byte case catch char class const continue debugger default delete do double else enum eval export extends false final finally float for function goto if implements import in instanceof int interface let long native new null package private protected public return short static super switch synchronized this throw throws transient true try typeof var void volatile while with yield'.split( ' ' );
+const reserved = 'process location abstract arguments boolean break byte case catch char class const continue debugger default delete do double else enum eval export extends false final finally float for function goto if implements import in instanceof int interface let long native new null package private protected public return short static super switch synchronized this throw throws transient true try typeof var void volatile while with yield'.split( ' ' );
 const blacklist = { __esModule: true };
 reserved.forEach( word => blacklist[ word ] = true );
 


### PR DESCRIPTION
Currently you can generate code with satements like 
`var process = ` or `var location = `
this is obviously a bad Idea vor node (case 1) or the browser (case 2)

Resolves https://github.com/rollup/rollup-plugin-commonjs/issues/309