### PR TITLE
Fix #337 Keep isCjsPromises between commonjs() calls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ function startsWith ( str, prefix ) {
 	return str.slice( 0, prefix.length ) === prefix;
 }
 
+const isCjsPromises = Object.create(null);
 
 export default function commonjs ( options = {} ) {
 	const extensions = options.extensions || ['.js'];
@@ -95,7 +96,6 @@ export default function commonjs ( options = {} ) {
 
 	let resolveUsingOtherResolvers;
 
-	const isCjsPromises = Object.create(null);
 	function getIsCjsPromise ( id ) {
 		let isCjsPromise = isCjsPromises[id];
 		if (isCjsPromise)

--- a/test/test.js
+++ b/test/test.js
@@ -7,7 +7,11 @@ const { SourceMapConsumer } = require( 'source-map' );
 const { getLocator } = require( 'locate-character' );
 const { rollup } = require( 'rollup' );
 const resolve = require( 'rollup-plugin-node-resolve' );
-const commonjs = require( '..' );
+
+function commonjs (options) {
+	delete require.cache[require.resolve('..')];
+	return require('..')(options);
+}
 
 require( 'source-map-support' ).install();
 
@@ -544,6 +548,22 @@ describe( 'rollup-plugin-commonjs', () => {
 				onwarn: (warn) => warns.push( warn )
 			});
 			assert.equal( warns.length, 0 );
+		});
+
+		it( 'compiles with cache', async () => {
+			// specific commonjs require() to ensure same instance is used
+			const commonjs = require('..');
+
+			const bundle = await rollup({
+				input: 'function/index/main.js',
+				plugins: [ commonjs() ]
+			});
+
+			await rollup({
+				input: 'function/index/main.js',
+				plugins: [ commonjs() ],
+				cache: bundle
+			});
 		});
 
 		it( 'creates an error with a code frame when parsing fails', async () => {


### PR DESCRIPTION
When using rollup cache, rollup won't call transform if it has a cache, so it appears the promise will never resolve because isCjsPromises is cleared between calls to commonjs().

I had to change the tests overall a bit to ensure they ran as if commonjs was loaded anew every time. I'm not sure it's the best way to do it though, but since there wasn't any state saved between runs until now it should be ok.