### PR TITLE
Prepare for 1.0.0, fix some issues

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -10,9 +10,13 @@ export function commonjsRequire () {
 }
 
 export function unwrapExports (x) {
-	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
+	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x.default : x;
 }
 
 export function createCommonjsModule(fn, module) {
 	return module = { exports: {} }, fn(module, module.exports), module.exports;
+}
+
+export function getCjsExportFromNamespace (n) {
+	return n && n.default || n;
 }`;

--- a/src/index.js
+++ b/src/index.js
@@ -75,10 +75,7 @@ export default function commonjs(options = {}) {
 				const actualId = id.slice(PROXY_PREFIX.length);
 				const name = getName(actualId);
 
-				return (extensions.indexOf(extname(id)) === -1
-					? Promise.resolve(false)
-					: getIsCjsPromise(actualId)
-				).then(isCjs => {
+				return getIsCjsPromise(actualId).then(isCjs => {
 					if (isCjs)
 						return `import { __moduleExports } from ${JSON.stringify(
 							actualId
@@ -97,8 +94,10 @@ export default function commonjs(options = {}) {
 		},
 
 		transform(code, id) {
-			if (!filter(id)) return null;
-			if (extensions.indexOf(extname(id)) === -1) return null;
+			if (!filter(id) || extensions.indexOf(extname(id)) === -1) {
+				setIsCjsPromise(id, Promise.resolve(null));
+				return null;
+			}
 
 			const transformPromise = entryModuleIdsPromise
 				.then(entryModuleIds => {

--- a/src/transform.js
+++ b/src/transform.js
@@ -1,9 +1,9 @@
-import {walk} from 'estree-walker';
+import { walk } from 'estree-walker';
 import MagicString from 'magic-string';
-import {attachScopes, makeLegalIdentifier} from 'rollup-pluginutils';
-import {extractNames, flatten, isFalsy, isReference, isTruthy} from './ast-utils.js';
-import {HELPERS_ID, PROXY_PREFIX} from './helpers.js';
-import {getName} from './utils.js';
+import { attachScopes, makeLegalIdentifier } from 'rollup-pluginutils';
+import { extractNames, flatten, isFalsy, isReference, isTruthy } from './ast-utils.js';
+import { HELPERS_ID, PROXY_PREFIX } from './helpers.js';
+import { getName } from './utils.js';
 
 const reserved = 'process location abstract arguments boolean break byte case catch char class const continue debugger default delete do double else enum eval export extends false final finally float for from function goto if implements import in instanceof int interface let long native new null package private protected public return short static super switch synchronized this throw throws transient true try typeof var void volatile while with yield'.split(
 	' '
@@ -47,14 +47,13 @@ export function checkEsModule(parse, code, id) {
 	const ast = tryParse(parse, code, id);
 
 	// if there are top-level import/export declarations, this is ES not CommonJS
-	let hasDefaultExport = false;
 	let isEsModule = false;
 	for (const node of ast.body) {
-		if (node.type === 'ExportDefaultDeclaration') hasDefaultExport = true;
+		if (node.type === 'ExportDefaultDeclaration') return {isEsModule: true, hasDefaultExport: true, ast};
 		if (importExportDeclaration.test(node.type)) isEsModule = true;
 	}
 
-	return { isEsModule, hasDefaultExport, ast };
+	return { isEsModule, hasDefaultExport: false, ast };
 }
 
 export function transformCommonjs(

--- a/src/transform.js
+++ b/src/transform.js
@@ -46,11 +46,18 @@ export function hasCjsKeywords(code, ignoreGlobal) {
 export function checkEsModule(parse, code, id) {
 	const ast = tryParse(parse, code, id);
 
-	// if there are top-level import/export declarations, this is ES not CommonJS
 	let isEsModule = false;
 	for (const node of ast.body) {
-		if (node.type === 'ExportDefaultDeclaration') return {isEsModule: true, hasDefaultExport: true, ast};
-		if (importExportDeclaration.test(node.type)) isEsModule = true;
+		if (node.type === 'ExportDefaultDeclaration')
+			return { isEsModule: true, hasDefaultExport: true, ast };
+		if (node.type === 'ExportNamedDeclaration') {
+			isEsModule = true;
+			for (const specifier of node.specifiers) {
+				if (specifier.exported.name === 'default') {
+					return { isEsModule: true, hasDefaultExport: true, ast };
+				}
+			}
+		} else if (importExportDeclaration.test(node.type)) isEsModule = true;
 	}
 
 	return { isEsModule, hasDefaultExport: false, ast };

--- a/test/function/export-default-from/_config.js
+++ b/test/function/export-default-from/_config.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/test/function/export-default-from/imported.js
+++ b/test/function/export-default-from/imported.js
@@ -1,0 +1,1 @@
+export default 'default export';

--- a/test/function/export-default-from/main.js
+++ b/test/function/export-default-from/main.js
@@ -1,0 +1,1 @@
+assert.equal(require('./reexporter'), 'default export');

--- a/test/function/export-default-from/reexporter.js
+++ b/test/function/export-default-from/reexporter.js
@@ -1,0 +1,1 @@
+export {default} from './imported';

--- a/test/function/resolve-is-cjs-extension/_config.js
+++ b/test/function/resolve-is-cjs-extension/_config.js
@@ -1,0 +1,15 @@
+module.exports = {
+	description: 'always resolve cjs detection even if an imported file has an unknown extension',
+	options: {
+		plugins: [
+			{
+				resolveId(importee) {
+					if (importee === 'second') {
+						return `${__dirname}/second.x`;
+					}
+				}
+			}
+		]
+	},
+	pluginOptions: {}
+};

--- a/test/function/resolve-is-cjs-extension/main.js
+++ b/test/function/resolve-is-cjs-extension/main.js
@@ -1,0 +1,1 @@
+assert.equal(require('second').result, 'second' );

--- a/test/function/resolve-is-cjs-extension/second.x
+++ b/test/function/resolve-is-cjs-extension/second.x
@@ -1,0 +1,1 @@
+export const result = 'second';

--- a/test/function/resolve-is-cjs-filtered/_config.js
+++ b/test/function/resolve-is-cjs-filtered/_config.js
@@ -1,0 +1,17 @@
+module.exports = {
+	description: 'always resolve cjs detection even if an imported file is filtered',
+	options: {
+		plugins: [
+			{
+				resolveId(importee) {
+					if (importee === 'second') {
+						return `${__dirname}/second.js`;
+					}
+				}
+			}
+		]
+	},
+	pluginOptions: {
+		include: ['function/resolve-is-cjs-filtered/main.js']
+	}
+};

--- a/test/function/resolve-is-cjs-filtered/main.js
+++ b/test/function/resolve-is-cjs-filtered/main.js
@@ -1,0 +1,1 @@
+assert.equal(require('second').result, 'second' );

--- a/test/function/resolve-is-cjs-filtered/second.js
+++ b/test/function/resolve-is-cjs-filtered/second.js
@@ -1,0 +1,1 @@
+export const result = 'second';


### PR DESCRIPTION
Besides making the tests ready for rollup@1.0.0 (the production code was already working), this will also fix two issues:
* resolves #348 by extending the default export detection logic to search for both `export default ...` as well as `export {... as default}`.
* resolves #341 by properly setting the CJS promise for filtered and otherwise ignored files

Furthermore, it prevents a `default is not exported` warning by putting the ESM import wrapper into a function which is not optimized by rollup. Lastly, importing ESM with known default exports will produce more optimized code.