### PR TITLE
fix: avoid ES6 export for entry files w/o exports

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -459,7 +459,7 @@ export function transformCommonjs(
 			}
 		});
 
-		if (!hasDefaultExport) {
+		if (!hasDefaultExport && (names.length || !isEntry)) {
 			wrapperEnd = `\n\nvar ${moduleName} = {\n${names
 				.map(({ name, deconflicted }) => `\t${name}: ${deconflicted}`)
 				.join(',\n')}\n};`;
@@ -488,7 +488,11 @@ export function transformCommonjs(
 		.trim()
 		.prepend(importBlock + wrapperStart)
 		.trim()
-		.append(wrapperEnd + exportBlock);
+		.append(wrapperEnd);
+
+	if (hasDefaultExport || named.length > 0 || shouldWrap || !isEntry) {
+		magicString.append(exportBlock);
+	}
 
 	code = magicString.toString();
 	const map = sourceMap ? magicString.generateMap() : null;

--- a/test/form/no-exports-entry/_config.js
+++ b/test/form/no-exports-entry/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	options: {
+		ignore: [ 'foo' ]
+	},
+	entry: './input.js'
+};

--- a/test/form/no-exports-entry/input.js
+++ b/test/form/no-exports-entry/input.js
@@ -1,0 +1,7 @@
+var dummy = require('./dummy');
+
+var foo = function () {
+	return;
+};
+
+var input = 42;

--- a/test/form/no-exports-entry/output.js
+++ b/test/form/no-exports-entry/output.js
@@ -1,0 +1,8 @@
+import './dummy';
+import dummy from '_./dummy?commonjs-proxy';
+
+var foo = function () {
+	return;
+};
+
+var input = 42;


### PR DESCRIPTION
No ES6 export is added to _entry_ files containing no CommonJS export.

E.g. this _entry_ file named `xyz/index.js` containing
```
var dummy = require('./dummy');
var input = 42;
```

This PR makes the above code which doesn't contain any `exports` use transformed into the following containing _no ES6 export_:
```
import './dummy';
import dummy from 'commonjs-proxy:./dummy';
var input = 42;
```

In master branchy it adds an empty object `module.exports` clause which is useful for non-entry files but not desirable for entry files:
```
import './dummy';
import dummy from 'commonjs-proxy:./dummy';
var input = 42;

var xyz = {

};

module.exports = xyz;
```

