### PR TITLE
Support try-catch optional requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ export default {
       // (see below for more details)
       namedExports: { './module.js': ['foo', 'bar' ] },  // Default: undefined
 
+      // specify which module resolutions are missing and should be replaced
+      // with an explicit not found error in the build itself
+      isMissing: (id, parentId) => id === 'supports-color';
+
       // sometimes you have to leave require statements
       // unconverted. Pass an array containing the IDs
       // or a `id => boolean` function. Only use this

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -19,4 +19,11 @@ export function createCommonjsModule(fn, module) {
 
 export function getCjsExportFromNamespace (n) {
 	return n && n.default || n;
-}`;
+}
+
+export function notFoundRequire (id) {
+	var e = new Error("Cannot find module '" + id + "'.");
+	e.code = 'MODULE_NOT_FOUND';
+	throw e;
+}
+`;

--- a/src/index.js
+++ b/src/index.js
@@ -117,7 +117,8 @@ export default function commonjs(options = {}) {
 						customNamedExports[id],
 						sourceMap,
 						allowDynamicRequire,
-						ast
+						ast,
+						options.isMissing
 					)
 					.then(transformed => {
 						if (!transformed) {

--- a/src/transform.js
+++ b/src/transform.js
@@ -384,10 +384,6 @@ export function transformCommonjs(
 			return Promise.all(sources.map((source, index) => {
 				if (required[source].optional.length) {
 					return this.resolveId(source, id)
-					.then(x => {
-						if (!x)
-							toError.push(index)
-					})
 					.catch(() => {
 						toError.push(index);
 					});

--- a/src/transform.js
+++ b/src/transform.js
@@ -72,7 +72,8 @@ export function transformCommonjs(
 	customNamedExports,
 	sourceMap,
 	allowDynamicRequire,
-	astCache
+	astCache,
+	isMissing
 ) {
 	return Promise.resolve()
 	.then(() => {
@@ -382,10 +383,14 @@ export function transformCommonjs(
 			// before constructing the import block, remove any optional dependencies that won't resolve
 			let toError = [];
 			return Promise.all(sources.map((source, index) => {
-				if (required[source].optional.length) {
-					return this.resolveId(source, id)
-					.catch(() => {
-						toError.push(index);
+				if (required[source].optional.length && typeof isMissing === 'function') {
+					return Promise.resolve()
+					.then(function () {
+						return isMissing(source, id);
+					})
+					.then(isMissing => {
+						if (isMissing)
+							toError.push(index);
 					});
 				}
 			}))

--- a/test/function/optional-require/_config.js
+++ b/test/function/optional-require/_config.js
@@ -1,7 +1,11 @@
 const assert = require('assert');
 
 module.exports = {
-	solo: true,
+	pluginOptions: {
+		isMissing(id) {
+			return id === 'does-not-exist';
+		}
+	},
 	exports: exports => {
 		assert.equal(exports.caughtOk, true);
 	}

--- a/test/function/optional-require/_config.js
+++ b/test/function/optional-require/_config.js
@@ -1,0 +1,8 @@
+const assert = require('assert');
+
+module.exports = {
+	solo: true,
+	exports: exports => {
+		assert.equal(exports.caughtOk, true);
+	}
+};

--- a/test/function/optional-require/main.js
+++ b/test/function/optional-require/main.js
@@ -1,7 +1,8 @@
 try {
+  var fs = require('fs');
   require('does-not-exist');
 }
 catch (err) {
-  if (err instanceof Error && err.message === 'Cannot find module \'does-not-exist\'.')
+  if (err instanceof Error && err.message === 'Cannot find module \'does-not-exist\'.' && fs)
     exports.caughtOk = true;
 }

--- a/test/function/optional-require/main.js
+++ b/test/function/optional-require/main.js
@@ -1,0 +1,7 @@
+try {
+  require('does-not-exist');
+}
+catch (err) {
+  if (err instanceof Error && err.message === 'Cannot find module \'does-not-exist\'.')
+    exports.caughtOk = true;
+}


### PR DESCRIPTION
When a require does not resolve that exists within a try-catch statement, this PR supports that being emitted as an inlined "module not found" error.

This is useful for example with try-catch statements in optional dependencies.

In order to run the async resolver within the transform function to determine if these optional dependencies resolve or not, the entire transform function has been made async, which makes the diff look like more than there is unfortunately.

I did try moving to async/await but I'm not sure the codebase is ready for that? Happy to as well if we can though.