### PR TITLE
WIP: Support type information (*.d.ts).

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2457,8 +2457,12 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "lodash-es": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.11.tgz",
+      "integrity": "sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q=="
     },
     "log-symbols": {
       "version": "2.2.0",
@@ -3869,8 +3873,7 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "dev": true
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "type-check": {
       "version": "0.3.2",
@@ -3879,6 +3882,22 @@
       "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
+      }
+    },
+    "typescript": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
+      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA=="
+    },
+    "typescript-parser": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/typescript-parser/-/typescript-parser-2.6.1.tgz",
+      "integrity": "sha512-p4ZC10pu67KO8+WJALsJWhbAq4pRBIcP+ls8Bhl+V8KvzYQDwxw/P5hJhn3rBdLnfS5aGLflfh7WiZpN6yi+5g==",
+      "requires": {
+        "lodash": "^4.17.10",
+        "lodash-es": "^4.17.10",
+        "tslib": "^1.9.3",
+        "typescript": "^3.0.3"
       }
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "estree-walker": "^0.5.2",
     "magic-string": "^0.25.1",
     "resolve": "^1.8.1",
-    "rollup-pluginutils": "^2.3.3"
+    "rollup-pluginutils": "^2.3.3",
+    "typescript-parser": "^2.6.1"
   },
   "devDependencies": {
     "acorn": "^6.0.2",

--- a/src/default-resolver.js
+++ b/src/default-resolver.js
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import {dirname, resolve} from 'path';
+import { dirname, resolve } from 'path';
 
 function isFile(file) {
 	try {

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,11 @@
-import { dirname, extname, resolve } from 'path';
+import { extname, resolve } from 'path';
 import { sync as nodeResolveSync } from 'resolve';
 import { createFilter } from 'rollup-pluginutils';
 import { EXTERNAL_PREFIX, HELPERS, HELPERS_ID, PROXY_PREFIX } from './helpers.js';
 import { getIsCjsPromise, setIsCjsPromise } from './is-cjs';
 import { getResolveId } from './resolve-id';
 import { checkEsModule, hasCjsKeywords, transformCommonjs } from './transform.js';
-import { getName, getTypeInfoNamedExports } from './utils.js';
+import { getName, getTypeInfoExports } from './utils.js';
 
 export default function commonjs(options = {}) {
 	const extensions = options.extensions || ['.js'];
@@ -97,12 +97,12 @@ export default function commonjs(options = {}) {
 				setIsCjsPromise(id, Promise.resolve(null));
 				return null;
 			}
-			const typeInfoNamedExportsPromise = getTypeInfoNamedExports(dirname(id));
+			const typeInfoExportsPromise = getTypeInfoExports(id);
 
-			const transformPromise = typeInfoNamedExportsPromise
-				.then(typeInfoNamedExports => Promise.all([typeInfoNamedExports, entryModuleIdsPromise]))
+			const transformPromise = typeInfoExportsPromise
+				.then(typeInfoExports => Promise.all([typeInfoExports, entryModuleIdsPromise]))
 				.then(promises => {
-					const [typeInfoNamedExports, entryModuleIds] = promises;
+					const [typeInfoExports, entryModuleIds] = promises;
 					const { isEsModule, hasDefaultExport, ast } = checkEsModule(this.parse, code, id);
 					if (isEsModule) {
 						(hasDefaultExport ? esModulesWithDefaultExport : esModulesWithoutDefaultExport)[
@@ -119,8 +119,8 @@ export default function commonjs(options = {}) {
 
 					const namedExports =
 						customNamedExports[id] === undefined
-							? typeInfoNamedExports
-							: [...customNamedExports[id], ...typeInfoNamedExports];
+							? typeInfoExports
+							: [...customNamedExports[id], ...typeInfoExports];
 
 					const transformed = transformCommonjs(
 						this.parse,

--- a/src/resolve-id.js
+++ b/src/resolve-id.js
@@ -1,8 +1,8 @@
-import {statSync} from 'fs';
-import {dirname, resolve, sep} from 'path';
+import { statSync } from 'fs';
+import { dirname, resolve, sep } from 'path';
 import defaultResolver from './default-resolver';
-import {EXTERNAL_PREFIX, PROXY_PREFIX} from './helpers';
-import {first} from './utils';
+import { EXTERNAL_PREFIX, PROXY_PREFIX } from './helpers';
+import { first } from './utils';
 
 function getCandidatesForExtension(resolved, extension) {
 	return [resolved + extension, resolved + `${sep}index${extension}`];

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs';
 import { basename, dirname, extname, resolve, sep } from 'path';
 import { makeLegalIdentifier } from 'rollup-pluginutils';
-import { TypescriptParser } from 'typescript-parser';
+import { TypescriptParser, DefaultDeclaration } from 'typescript-parser';
 
 export function getName(id) {
 	const name = makeLegalIdentifier(basename(id, extname(id)));
@@ -40,7 +40,11 @@ export async function getTypeInfoNamedExports(importDir) {
 			const typesExports = parsed.declarations
 				.map(declaration => {
 					if (declaration.isExported) {
-						return declaration.name;
+						if (declaration instanceof DefaultDeclaration) {
+							return 'default';
+						} else {
+							return declaration.name;
+						}
 					}
 					return null;
 				})

--- a/test/test.js
+++ b/test/test.js
@@ -719,4 +719,42 @@ module.exports = main;
 			);
 		});
 	});
+
+	describe('typed', () => {
+		fs.readdirSync('typed').forEach(dir => {
+			let config;
+
+			try {
+				config = require(`./typed/${dir}/_config.js`);
+			} catch (err) {
+				config = {};
+			}
+
+			(config.solo ? it.only : it)(dir, async () => {
+				const options = Object.assign(
+					{
+						input: `typed/${dir}/test.js`
+					},
+					config.options || {},
+					{
+						plugins: [
+							...((config.options && config.options.plugins) || []),
+							commonjs(config.pluginOptions)
+						]
+					}
+				);
+
+				const bundle = await rollup(options);
+				const code = await getCodeFromBundle(bundle);
+				if (config.show || config.solo) {
+					console.error(code);
+				}
+
+				const { exports, global } = execute(code, config.context);
+
+				if (config.exports) config.exports(exports);
+				if (config.global) config.global(global);
+			});
+		});
+	});
 });

--- a/test/typed/defaultFunctionExport/main.d.ts
+++ b/test/typed/defaultFunctionExport/main.d.ts
@@ -1,0 +1,1 @@
+export default function foo(): number;

--- a/test/typed/defaultFunctionExport/main.js
+++ b/test/typed/defaultFunctionExport/main.js
@@ -1,0 +1,9 @@
+const toExport = {};
+
+function foo() {
+	return 42;
+}
+
+toExport.default = foo;
+
+module.exports = toExport;

--- a/test/typed/defaultFunctionExport/package.json
+++ b/test/typed/defaultFunctionExport/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test",
+  "main": "main.js",
+  "types": "main.d.ts"
+}

--- a/test/typed/defaultFunctionExport/test.js
+++ b/test/typed/defaultFunctionExport/test.js
@@ -1,0 +1,3 @@
+import foo from './main.js';
+
+assert.equal(foo(), 42);

--- a/test/typed/miltiFileExport/foo.d.ts
+++ b/test/typed/miltiFileExport/foo.d.ts
@@ -1,0 +1,1 @@
+export default function foo(): number;

--- a/test/typed/miltiFileExport/foo.js
+++ b/test/typed/miltiFileExport/foo.js
@@ -1,0 +1,8 @@
+const toExport = {};
+
+function foo() {
+	return 42;
+}
+toExport.default = foo;
+
+module.exports = toExport;

--- a/test/typed/miltiFileExport/main.d.ts
+++ b/test/typed/miltiFileExport/main.d.ts
@@ -1,0 +1,3 @@
+import * as foo_import from './foo';
+export declare const foo: typeof foo_import.default;
+export declare function bar(): string;

--- a/test/typed/miltiFileExport/main.js
+++ b/test/typed/miltiFileExport/main.js
@@ -1,0 +1,12 @@
+const toExport = {};
+
+const foo = require("./foo");
+
+toExport.foo = foo.default;
+
+function bar() {
+	return 'hello world';
+}
+toExport.bar = bar;
+
+module.exports = toExport;

--- a/test/typed/miltiFileExport/package.json
+++ b/test/typed/miltiFileExport/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test",
+  "main": "main.js",
+  "types": "main.d.ts"
+}

--- a/test/typed/miltiFileExport/test.js
+++ b/test/typed/miltiFileExport/test.js
@@ -1,0 +1,4 @@
+import * as main from './main.js';
+
+assert.equal(main.foo(), 42);
+assert.equal(main.bar(), 'hello world');

--- a/test/typed/miltiFileWeirdnessExport/cjs/foo.js
+++ b/test/typed/miltiFileWeirdnessExport/cjs/foo.js
@@ -1,0 +1,8 @@
+const toExport = {};
+
+function foo() {
+	return 42;
+}
+toExport.default = foo;
+
+module.exports = toExport;

--- a/test/typed/miltiFileWeirdnessExport/cjs/main.js
+++ b/test/typed/miltiFileWeirdnessExport/cjs/main.js
@@ -1,0 +1,12 @@
+const toExport = {};
+
+const foo = require("./foo");
+
+toExport.foo = foo.default;
+
+function bar() {
+	return 'hello world';
+}
+toExport.bar = bar;
+
+module.exports = toExport;

--- a/test/typed/miltiFileWeirdnessExport/package.json
+++ b/test/typed/miltiFileWeirdnessExport/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test",
+  "main": "cjs/main.js",
+  "types": "types/altname.d.ts"
+}

--- a/test/typed/miltiFileWeirdnessExport/test.js
+++ b/test/typed/miltiFileWeirdnessExport/test.js
@@ -1,0 +1,4 @@
+import * as main from './cjs/main.js';
+
+assert.equal(main.foo(), 42);
+assert.equal(main.bar(), 'hello world');

--- a/test/typed/miltiFileWeirdnessExport/types/altname.d.ts
+++ b/test/typed/miltiFileWeirdnessExport/types/altname.d.ts
@@ -1,0 +1,3 @@
+import * as foo_import from './foo';
+export declare const foo: typeof foo_import.default;
+export declare function bar(): string;

--- a/test/typed/miltiFileWeirdnessExport/types/foo.d.ts
+++ b/test/typed/miltiFileWeirdnessExport/types/foo.d.ts
@@ -1,0 +1,1 @@
+export default function foo(): number;

--- a/test/typed/mixedFunctionExport/main.d.ts
+++ b/test/typed/mixedFunctionExport/main.d.ts
@@ -1,0 +1,2 @@
+export default function foo(): number;
+export declare function bar(): string;

--- a/test/typed/mixedFunctionExport/main.js
+++ b/test/typed/mixedFunctionExport/main.js
@@ -1,0 +1,14 @@
+const toExport = {};
+
+function foo() {
+	return 42;
+}
+toExport.default = foo;
+
+
+function bar() {
+	return 'hello world';
+}
+toExport.bar = bar;
+
+module.exports = toExport;

--- a/test/typed/mixedFunctionExport/package.json
+++ b/test/typed/mixedFunctionExport/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test",
+  "main": "main.js",
+  "types": "main.d.ts"
+}

--- a/test/typed/mixedFunctionExport/test.js
+++ b/test/typed/mixedFunctionExport/test.js
@@ -1,0 +1,4 @@
+import * as main from './main.js';
+
+assert.equal(main.default(), 42);
+assert.equal(main.bar(), 'hello world');

--- a/test/typed/namedClassExport/main.d.ts
+++ b/test/typed/namedClassExport/main.d.ts
@@ -1,0 +1,5 @@
+export declare class Foo {
+  bar: string;
+  constructor();
+  baz(): number;
+}

--- a/test/typed/namedClassExport/main.js
+++ b/test/typed/namedClassExport/main.js
@@ -1,0 +1,14 @@
+const toExport = {};
+
+class Foo {
+	constructor() {
+		this.bar = 'bar';
+	}
+
+	baz() {
+		return 42;
+	}
+}
+
+toExport.Foo = Foo;
+module.exports = toExport;

--- a/test/typed/namedClassExport/package.json
+++ b/test/typed/namedClassExport/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test",
+  "main": "main.js",
+  "types": "main.d.ts"
+}

--- a/test/typed/namedClassExport/test.js
+++ b/test/typed/namedClassExport/test.js
@@ -1,0 +1,5 @@
+import { Foo } from './main.js';
+
+const foo = new Foo();
+assert.equal(foo.bar, 'bar');
+assert.equal(foo.baz(), 42);

--- a/test/typed/namedExports/main.d.ts
+++ b/test/typed/namedExports/main.d.ts
@@ -1,0 +1,7 @@
+declare function foo(): number;
+declare function baz(): string;
+export { foo, baz as bar };
+declare function qux(): number;
+export { qux };
+declare function quux(): number;
+export default quux;

--- a/test/typed/namedExports/main.js
+++ b/test/typed/namedExports/main.js
@@ -1,0 +1,23 @@
+const toExport = {};
+
+function foo() {
+	return 42;
+}
+toExport.foo = foo;
+
+function baz() {
+	return 'hello world';
+}
+toExport.bar = baz;
+
+function qux() {
+	return 43;
+}
+toExport.qux = qux;
+
+function quux() {
+	return 44;
+}
+toExport.default = quux;
+
+module.exports = toExport;

--- a/test/typed/namedExports/package.json
+++ b/test/typed/namedExports/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test",
+  "main": "main.js",
+  "types": "main.d.ts"
+}

--- a/test/typed/namedExports/test.js
+++ b/test/typed/namedExports/test.js
@@ -1,0 +1,6 @@
+import * as main from './main.js';
+
+assert.equal(main.foo(), 42);
+assert.equal(main.bar(), 'hello world');
+assert.equal(main.qux(), 43);
+assert.equal(main.default(), 44);

--- a/test/typed/namedFunctionExport/main.d.ts
+++ b/test/typed/namedFunctionExport/main.d.ts
@@ -1,0 +1,2 @@
+export declare function foo(): number;
+export declare function bar(): string;

--- a/test/typed/namedFunctionExport/main.js
+++ b/test/typed/namedFunctionExport/main.js
@@ -1,0 +1,13 @@
+const toExport = {};
+
+function foo() {
+	return 42;
+}
+toExport.foo = foo;
+
+function bar() {
+	return 'hello world';
+}
+toExport.bar = bar;
+
+module.exports = toExport;

--- a/test/typed/namedFunctionExport/package.json
+++ b/test/typed/namedFunctionExport/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test",
+  "main": "main.js",
+  "types": "main.d.ts"
+}

--- a/test/typed/namedFunctionExport/test.js
+++ b/test/typed/namedFunctionExport/test.js
@@ -1,0 +1,4 @@
+import * as main from './main.js';
+
+assert.equal(main.foo(), 42);
+assert.equal(main.bar(), 'hello world');

--- a/test/typed/namedFunctionExportOtherwiseDetected/main.d.ts
+++ b/test/typed/namedFunctionExportOtherwiseDetected/main.d.ts
@@ -1,0 +1,1 @@
+export function foo(): number;

--- a/test/typed/namedFunctionExportOtherwiseDetected/main.js
+++ b/test/typed/namedFunctionExportOtherwiseDetected/main.js
@@ -1,0 +1,11 @@
+function foo() {
+	return 42;
+}
+
+module.exports.foo = foo;
+
+function bar() {
+	return 'hello world';
+}
+
+module.exports.bar = bar;

--- a/test/typed/namedFunctionExportOtherwiseDetected/package.json
+++ b/test/typed/namedFunctionExportOtherwiseDetected/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test",
+  "main": "main.js",
+  "types": "main.d.ts"
+}

--- a/test/typed/namedFunctionExportOtherwiseDetected/test.js
+++ b/test/typed/namedFunctionExportOtherwiseDetected/test.js
@@ -1,0 +1,4 @@
+import * as main from './main.js';
+
+assert.equal(main.foo(), 42);
+assert.equal(main.bar(), 'hello world');


### PR DESCRIPTION
The PR makes it so [type information](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) is used when available.

This helps avoid `Error: "[name] is not exported by [module]"`.

This PR probably isn't perfect as there are many test cases not being test yet. Further work will be required but I'd like to get some feedback on it in the meantime.

**Todo:**
- [ ] Add a bunch more test.
- [ ] Add support for `@types` declarations.
- [ ] Add support for declarations in user specified folders.

Plus more...