### PR TITLE
Don't rewrite require assignments as references

### DIFF
--- a/src/ast-utils.js
+++ b/src/ast-utils.js
@@ -10,6 +10,9 @@ export function isReference(node, parent) {
 	// disregard the `bar` in `export { foo as bar }`
 	if (parent.type === 'ExportSpecifier' && node !== parent.local) return false;
 
+	// disregard assigned references
+	if (parent.type === 'AssignmentExpression' && parent.left === node) return false;
+
 	return true;
 }
 

--- a/test/form/require-assignment/input.js
+++ b/test/form/require-assignment/input.js
@@ -1,0 +1,7 @@
+require = 'test';
+
+var input = {
+
+};
+
+export default input;

--- a/test/form/require-assignment/output.js
+++ b/test/form/require-assignment/output.js
@@ -1,0 +1,7 @@
+require = 'test';
+
+var input = {
+
+};
+
+export default input;


### PR DESCRIPTION
Formidable contains the following code:

```js
 (global.GENTLY) require = GENTLY.hijack(require);
```

which is rewritten as:

```js
import * as commonjsHelpers from 'commonjs-helpers';
if (commonjsHelpers.global.GENTLY) commonjsHelpers.require = commonjsHelpers.global.GENTLY.hijack(require);
```

which then throws INVALID_NAMESPACE_ASSIGNMENT in Rollup, even though the code path never runs.

To make cases like this still build, this just disables rewriting assigned require / global as commonJS namespace references which would otherwise always be build errors.