### PR TITLE
Add .d.ts typings file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,50 @@
+import { Plugin } from 'rollup';
+
+interface RollupCommonJSOptions {
+	/**
+	 * non-CommonJS modules will be ignored, but you can also
+	 * specifically include/exclude files
+	 * @default undefined
+	 */
+	include?: string | RegExp,
+	/**
+	 * non-CommonJS modules will be ignored, but you can also
+	 * specifically include/exclude files
+	 * @default undefined
+	 */
+	exclude?: ReadonlyArray<string | RegExp>
+	/**
+	 * search for files other than .js files (must already
+	 * be transpiled by a previous plugin!)
+	 * @default [ '.js' ]
+	 */
+	extensions: ReadonlyArray<string | RegExp>,
+	/**
+	 * if true then uses of `global` won't be dealt with by this plugin
+	 * @default false
+	 */
+	ignoreGlobal?: boolean,
+	/**
+	 * if false then skip sourceMap generation for CommonJS modules
+	 * @default true
+	 */
+	sourceMap?: boolean,
+	/**
+	 * explicitly specify unresolvable named exports
+	 * ([see below for more details](https://github.com/rollup/rollup-plugin-commonjs#custom-named-exports))
+	 * @default undefined
+	 */
+	namedExports?: { [package: string]: ReadonlyArray<string> },
+	/**
+	 * sometimes you have to leave require statements
+	 * unconverted. Pass an array containing the IDs
+	 * or a `id => boolean` function. Only use this
+	 * option if you know what you're doing!
+	 */
+	ignore?: ReadonlyArray<string | ((id: string) => boolean)>,
+}
+
+/**
+ * Convert CommonJS modules to ES6, so they can be included in a Rollup bundle
+ */
+export default function commonjs(options?: RollupCommonJSOptions): Plugin;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2537,7 +2537,7 @@
         "glob": "7.1.3",
         "growl": "1.10.5",
         "he": "1.2.0",
-        "js-yaml": "^3.13.0",
+        "js-yaml": "3.12.0",
         "log-symbols": "2.2.0",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
@@ -3815,6 +3815,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "typescript": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.1.tgz",
+      "integrity": "sha512-3NSMb2VzDQm8oBTLH6Nj55VVtUEpe/rgkIzMir0qVoLyjDZlnMBva0U6vDiV3IH+sl/Yu6oP5QwsAQtHPmDd2Q==",
+      "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -6,14 +6,13 @@
   "module": "dist/rollup-plugin-commonjs.es.js",
   "jsnext:main": "dist/rollup-plugin-commonjs.es.js",
   "scripts": {
-    "test": "npm run test:only && npm run test:ts",
-    "test:only": "mocha",
-    "test:ts": "tsc",
+    "test": "npm run test:only",
+    "test:only": "mocha && tsc",
     "pretest": "npm run build",
     "build": "shx rm -rf dist/* && rollup -c",
     "dev": "rollup -c -w",
     "lint": "prettier --write src/**/*.js test/test.js test/**/_config.js && eslint --fix src/**/*.js test/test.js test/**/_config.js",
-    "prepublishOnly": "npm run lint && npm run test:only && npm run test:ts",
+    "prepublishOnly": "npm run lint && npm run test:only",
     "prepare": "npm run build"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -6,13 +6,14 @@
   "module": "dist/rollup-plugin-commonjs.es.js",
   "jsnext:main": "dist/rollup-plugin-commonjs.es.js",
   "scripts": {
-    "test": "npm run test:only",
+    "test": "npm run test:only && npm run test:ts",
     "test:only": "mocha",
+    "test:ts": "tsc",
     "pretest": "npm run build",
     "build": "shx rm -rf dist/* && rollup -c",
     "dev": "rollup -c -w",
     "lint": "prettier --write src/**/*.js test/test.js test/**/_config.js && eslint --fix src/**/*.js test/test.js test/**/_config.js",
-    "prepublishOnly": "npm run lint && npm run test:only",
+    "prepublishOnly": "npm run lint && npm run test:only && npm run test:ts",
     "prepare": "npm run build"
   },
   "files": [
@@ -44,7 +45,8 @@
     "rollup-plugin-node-resolve": "^4.0.1",
     "shx": "^0.3.2",
     "source-map": "^0.7.3",
-    "source-map-support": "^0.5.11"
+    "source-map-support": "^0.5.11",
+    "typescript": "^3.4.1"
   },
   "repository": "rollup/rollup-plugin-commonjs",
   "author": "Rich Harris",

--- a/test/typings-test.js
+++ b/test/typings-test.js
@@ -1,7 +1,7 @@
 // @ts-check
-import commonjs from '.';
+import commonjs from '..';
 
-/** @type {import("rollup").RollupFileOptions} */
+/** @type {import("rollup").RollupOptions} */
 const config = {
 	input: 'main.js',
 	output: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
     },
     "files": [
         "index.d.ts",
-        "test/typings-test.js"
+        "typings-test.js"
     ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strict": true,
+        "noEmit": true,
+        "allowJs": true
+    },
+    "files": [
+        "index.d.ts",
+        "test/typings-test.js"
+    ]
+}

--- a/typings-test.js
+++ b/typings-test.js
@@ -1,5 +1,5 @@
 // @ts-check
-import commonjs from '..';
+import commonjs from '.';
 
 /** @type {import("rollup").RollupOptions} */
 const config = {

--- a/typings-test.js
+++ b/typings-test.js
@@ -1,0 +1,24 @@
+// @ts-check
+import commonjs from '.';
+
+/** @type {import("rollup").RollupFileOptions} */
+const config = {
+	input: 'main.js',
+	output: {
+		file: 'bundle.js',
+		format: 'iife'
+	},
+	plugins: [
+		commonjs({
+			include: 'node_modules/**',
+			exclude: [ 'node_modules/foo/**', 'node_modules/bar/**', /node_modules/ ],
+			extensions: [ '.js', '.coffee' ],
+			ignoreGlobal: false,
+			sourceMap: false,
+			namedExports: { './module.js': ['foo', 'bar' ] },
+			ignore: [ 'conditional-runtime-dependency' ]
+		})
+	]
+};
+
+export default config;


### PR DESCRIPTION
Adds a [.d.ts TypeScript declaration file](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) to support typechecking a Rollup config with TypeScript.

TypeScript allows for checking normal Javascript files by adding a `// @ts-check` comment at the top of the file. By providing typings users can check that they aren't passing misspelled or incorrect parameters, and see a hint about what each option does in their editor.

![typings-demo-commonjs](https://user-images.githubusercontent.com/1782266/49924527-72749980-fe6b-11e8-948e-c2c8a57ef469.png)
