### PR TITLE
fix: remove colon from module prefixes

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,5 @@
-export const PROXY_PREFIX = '\0commonjs-proxy:';
-export const EXTERNAL_PREFIX = '\0commonjs-external:';
+export const PROXY_PREFIX = '\0commonjs-proxy-';
+export const EXTERNAL_PREFIX = '\0commonjs-external-';
 export const HELPERS_ID = '\0commonjsHelpers';
 
 export const HELPERS = `

--- a/test/form/constant-template-literal/output.js
+++ b/test/form/constant-template-literal/output.js
@@ -1,5 +1,5 @@
 import 'tape';
-import foo from 'commonjs-proxy:tape';
+import foo from 'commonjs-proxy-tape';
 
 console.log(foo);
 

--- a/test/form/ignore-ids-function/output.js
+++ b/test/form/ignore-ids-function/output.js
@@ -1,5 +1,5 @@
 import 'bar';
-import bar from 'commonjs-proxy:bar';
+import bar from 'commonjs-proxy-bar';
 
 var foo = require( 'foo' );
 

--- a/test/form/ignore-ids/output.js
+++ b/test/form/ignore-ids/output.js
@@ -1,5 +1,5 @@
 import 'bar';
-import bar from 'commonjs-proxy:bar';
+import bar from 'commonjs-proxy-bar';
 
 var foo = require( 'foo' );
 

--- a/test/form/multiple-var-declarations-b/output.js
+++ b/test/form/multiple-var-declarations-b/output.js
@@ -1,5 +1,5 @@
 import './a';
-import a from 'commonjs-proxy:./a';
+import a from 'commonjs-proxy-./a';
 
 var b = 42;
 

--- a/test/form/multiple-var-declarations-c/output.js
+++ b/test/form/multiple-var-declarations-c/output.js
@@ -1,5 +1,5 @@
 import './b';
-import b from 'commonjs-proxy:./b';
+import b from 'commonjs-proxy-./b';
 
 var a = 'a'
   , c = 'c';

--- a/test/form/multiple-var-declarations/output.js
+++ b/test/form/multiple-var-declarations/output.js
@@ -1,7 +1,7 @@
 import './a';
 import './b';
-import require$$0 from 'commonjs-proxy:./a';
-import b from 'commonjs-proxy:./b';
+import require$$0 from 'commonjs-proxy-./a';
+import b from 'commonjs-proxy-./b';
 
 var a = require$$0();
 

--- a/test/form/require-collision/output.js
+++ b/test/form/require-collision/output.js
@@ -1,5 +1,5 @@
 import 'foo';
-import require$$1 from 'commonjs-proxy:foo';
+import require$$1 from 'commonjs-proxy-foo';
 
 (function() {
   var foo = require$$1;


### PR DESCRIPTION
When using Rollup with the `preserveModules` option set, it outputs all modules to files. External commonjs modules end up with a file name like `_commonjs-external:modulename`. Using a colon inside a file name is invalid and results in a lot of problems.