### PR TITLE
Make generated helper file have .js extension in preserveModules mode

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,6 +1,6 @@
 export const PROXY_PREFIX = '\0commonjs-proxy:';
 export const EXTERNAL_PREFIX = '\0commonjs-external:';
-export const HELPERS_ID = '\0commonjsHelpers';
+export const HELPERS_ID = '\0commonjsHelpers.js';
 
 export const HELPERS = `
 export var commonjsGlobal = typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -3,7 +3,7 @@ export const EXTERNAL_PREFIX = '\0commonjs-external:';
 export const HELPERS_ID = '\0commonjsHelpers.js';
 
 export const HELPERS = `
-export var commonjsGlobal = typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
+export var commonjsGlobal = typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
 
 export function commonjsRequire () {
 	throw new Error('Dynamic requires are not currently supported by rollup-plugin-commonjs');

--- a/test/form/dynamic-template-literal/output.js
+++ b/test/form/dynamic-template-literal/output.js
@@ -1,4 +1,4 @@
-import * as commonjsHelpers from 'commonjsHelpers';
+import * as commonjsHelpers from 'commonjsHelpers.js';
 
 var pe = 'pe';
 var foo = commonjsHelpers.commonjsRequire(`ta${pe}`);

--- a/test/form/typeof-module-exports/output.js
+++ b/test/form/typeof-module-exports/output.js
@@ -1,4 +1,4 @@
-import * as commonjsHelpers from 'commonjsHelpers';
+import * as commonjsHelpers from 'commonjsHelpers.js';
 
 var input = commonjsHelpers.createCommonjsModule(function (module, exports) {
 var foo = 42;


### PR DESCRIPTION
I'm using rollup to build files for a custom JS platform that has es module support, but it does require `.js` extensions for all modules.

If you use this plugin with `preserveModules` turned on, it generates a file `_virtual/_commonjsHelpers` with no extension.