### PR TITLE
fix: prevent error for extractors.ArrayPattern with MemberExpression

### DIFF
--- a/src/ast-utils.js
+++ b/src/ast-utils.js
@@ -50,7 +50,9 @@ const extractors = {
 
 	ArrayPattern(names, node) {
 		node.elements.forEach(element => {
-			if (element) extractors[element.type](names, element);
+			if (element && element.type !== 'MemberExpression') {
+				extractors[element.type](names, element);
+			}
 		});
 	},
 

--- a/test/function/reassignment/main.js
+++ b/test/function/reassignment/main.js
@@ -1,8 +1,8 @@
 var foo = require( './foo.js' );
 
 if ( !foo.something ) {
-	foo = function somethingElse () {}
-	foo.something = true;
+	foo = function somethingElse () {};
+	[foo.something] = [true];
 }
 
 assert.ok( foo.something );


### PR DESCRIPTION
This fix prevent `extractNames` to throw `TypeError: extractors[element.type] is not a function`
when it encounter an array destructuring with MemberExpression like here 
https://github.com/babel/babel/blob/2817844e895b8999b71ec89ba008180c07b2f66d/packages/babel-parser/src/plugins/flow.js#L192