### PR TITLE
Added support for ancient ES3 browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # rollup-plugin-commonjs changelog
 
+## 9.2.3
+*2019-03-30*
+* Added support for ES3 ancient browsers ([#364](https://github.com/rollup/rollup-plugin-commonjs/issues/364))
+
 ## 9.2.2
 *2019-03-25*
 * Handle array destructuring assignment ([#379](https://github.com/rollup/rollup-plugin-commonjs/issues/379))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-commonjs",
-  "version": "9.2.2",
+  "version": "9.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2537,7 +2537,7 @@
         "glob": "7.1.3",
         "growl": "1.10.5",
         "he": "1.2.0",
-        "js-yaml": "^3.13.0",
+        "js-yaml": "3.12.0",
         "log-symbols": "2.2.0",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-commonjs",
-  "version": "9.2.2",
+  "version": "9.2.3",
   "description": "Convert CommonJS modules to ES2015",
   "main": "dist/rollup-plugin-commonjs.cjs.js",
   "module": "dist/rollup-plugin-commonjs.es.js",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2,6 +2,8 @@ export const PROXY_PREFIX = '\0commonjs-proxy:';
 export const EXTERNAL_PREFIX = '\0commonjs-external:';
 export const HELPERS_ID = '\0commonjsHelpers';
 
+// `x['default']` is used instead of `x.default` for backward compatibility with ES3 browsers.
+// Minifiers like uglify will usually transpile it back if compatibility with ES3 is not enabled.
 export const HELPERS = `
 export var commonjsGlobal = typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
 
@@ -10,7 +12,7 @@ export function commonjsRequire () {
 }
 
 export function unwrapExports (x) {
-	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x.default : x;
+	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
 }
 
 export function createCommonjsModule(fn, module) {
@@ -18,5 +20,5 @@ export function createCommonjsModule(fn, module) {
 }
 
 export function getCjsExportFromNamespace (n) {
-	return n && n.default || n;
+	return n && n['default'] || n;
 }`;


### PR DESCRIPTION
Added support for ancient ES3 browsers, like IE6, IE7, IE8 without breaking compatibility with modern browsers. The build output after minifiers will depend on minifier configuration. For example, `uglifyjs` will keep `x['default']` if `{ ie8: true }` is set and will convert back to `x.default` if not set. This is a safe change that will add ES3 support for free without impact on modern browsers.

Fixes #364