### PR TITLE
Include index.d.ts in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "files": [
     "src",
     "dist",
+    "index.d.ts",
     "README.md"
   ],
   "peerDependencies": {


### PR DESCRIPTION
I added the index.d.ts file but forgot to include it in the "files" field in package.json, so its not distributed with the npm package.

> @lukastaegert The typing file does not exists in the package available on npm registry.
> I think this part is missing in ```package.json``` file : 
> ```json
> "files": [
>     "dist/*.js",
>     "dist/*.d.ts"
>   ],
> ```
> And maybe also : 
> ```json
>  "typings": "index.d.ts",
> ```

_Originally posted by @nicolashenry in https://github.com/rollup/rollup-plugin-commonjs/pull/363#issuecomment-479429969_