### PR TITLE
Use extractAssignedNames from rollup-pluginutils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,9 +49,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "11.11.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
-      "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.0.tgz",
+      "integrity": "sha512-rx29MMkRdVmzunmiA4lzBYJNnXsW/PhG4kMBy2ATsYaDjGGR75dCFEVVROKpNwlVdcUX3xxlghKQOeDPBJobng==",
       "dev": true
     },
     "acorn": {
@@ -330,7 +330,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
-      "dev": true,
       "requires": {
         "callsites": "^2.0.0"
       },
@@ -338,8 +337,7 @@
         "callsites": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-          "dev": true
+          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
         }
       }
     },
@@ -347,7 +345,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
       "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
-      "dev": true,
       "requires": {
         "caller-callsite": "^2.0.0"
       }
@@ -842,9 +839,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "5.15.3",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.15.3.tgz",
-      "integrity": "sha512-vMGi0PjCHSokZxE0NLp2VneGw5sio7SSiDNgIUn2tC0XkWJRNOIoHIg3CliLVfXnJsiHxGAYrkw0PieAu8+KYQ==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
+      "integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -867,7 +864,7 @@
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "inquirer": "^6.2.2",
-        "js-yaml": "^3.12.0",
+        "js-yaml": "^3.13.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
         "lodash": "^4.17.11",
@@ -1600,33 +1597,6 @@
         "slash": "^2.0.0"
       },
       "dependencies": {
-        "cosmiconfig": {
-          "version": "5.0.7",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.7.tgz",
-          "integrity": "sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==",
-          "dev": true,
-          "requires": {
-            "import-fresh": "^2.0.0",
-            "is-directory": "^0.3.1",
-            "js-yaml": "^3.9.0",
-            "parse-json": "^4.0.0"
-          }
-        },
-        "execa": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^4.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -1636,20 +1606,9 @@
             "locate-path": "^3.0.0"
           }
         },
-        "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
         "import-fresh": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+          "version": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
           "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
-          "dev": true,
           "requires": {
             "caller-path": "^2.0.0",
             "resolve-from": "^3.0.0"
@@ -1728,8 +1687,7 @@
         "resolve-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-          "dev": true
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
         }
       }
     },
@@ -2537,7 +2495,7 @@
         "glob": "7.1.3",
         "growl": "1.10.5",
         "he": "1.2.0",
-        "js-yaml": "3.12.0",
+        "js-yaml": "3.13.0",
         "log-symbols": "2.2.0",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
@@ -2853,9 +2811,9 @@
       "dev": true
     },
     "parent-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
-      "integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "requires": {
         "callsites": "^3.0.0"
@@ -3180,9 +3138,9 @@
       }
     },
     "rollup": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.7.3.tgz",
-      "integrity": "sha512-U3/HaZujvGofNZQldfIknKoaNFNRS+j8/uCS/jSy3FrxF9t0FBsgZW4+VXLHG7l1daTgE6+jEy0Dv7cVCB2NPg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.8.0.tgz",
+      "integrity": "sha512-dKxL6ihUZ9YrVySKf/LBz5joW2sqwWkiuki34279Ppr2cL+O6Za6Ujovk+rtTX0AFCIsH1rs6y8LYKdZZ/7C5A==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
@@ -3220,19 +3178,12 @@
       }
     },
     "rollup-pluginutils": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.5.0.tgz",
-      "integrity": "sha512-9Muh1H+XB5f5ONmKMayUoTYR1EZwHbwJJ9oZLrKT5yuTf/RLIQ5mYIGsrERquVucJmjmaAW0Y7+6Qo1Ep+5w3Q==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.6.0.tgz",
+      "integrity": "sha512-aGQwspEF8oPKvg37u3p7h0cYNwmJR1sCBMZGZ5b9qy8HGtETknqjzcxrDRrcAnJNXN18lBH4Q9vZYth/p4n8jQ==",
       "requires": {
         "estree-walker": "^0.6.0",
         "micromatch": "^3.1.10"
-      },
-      "dependencies": {
-        "estree-walker": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.0.tgz",
-          "integrity": "sha512-peq1RfVAVzr3PU/jL31RaOjUKLoZJpObQWJJ+LgfcxDUifyLZ1RjPQZTl0pzj2uJ45b7A7XpyppXvxdEqzo4rw=="
-        }
       }
     },
     "run-async": {

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "estree-walker": "^0.6.0",
     "magic-string": "^0.25.2",
     "resolve": "^1.10.0",
-    "rollup-pluginutils": "^2.5.0"
+    "rollup-pluginutils": "^2.6.0"
   },
   "devDependencies": {
     "acorn": "^6.1.1",
-    "eslint": "^5.15.3",
+    "eslint": "^5.16.0",
     "eslint-plugin-import": "^2.16.0",
     "husky": "^1.3.1",
     "lint-staged": "^8.1.5",
@@ -40,7 +40,7 @@
     "mocha": "^6.0.2",
     "prettier": "^1.16.4",
     "require-relative": "^0.8.7",
-    "rollup": "^1.7.3",
+    "rollup": "^1.8.0",
     "rollup-plugin-buble": "^0.19.6",
     "rollup-plugin-node-resolve": "^4.0.1",
     "shx": "^0.3.2",

--- a/src/ast-utils.js
+++ b/src/ast-utils.js
@@ -31,42 +31,6 @@ export function flatten(node) {
 	return { name, keypath: parts.join('.') };
 }
 
-export function extractNames(node) {
-	const names = [];
-	extractors[node.type](names, node);
-	return names;
-}
-
-const extractors = {
-	Identifier(names, node) {
-		names.push(node.name);
-	},
-
-	ObjectPattern(names, node) {
-		node.properties.forEach(prop => {
-			extractors[prop.value.type](names, prop.value);
-		});
-	},
-
-	ArrayPattern(names, node) {
-		node.elements.forEach(element => {
-			if (element) extractors[element.type](names, element);
-		});
-	},
-
-	RestElement(names, node) {
-		extractors[node.argument.type](names, node.argument);
-	},
-
-	AssignmentPattern(names, node) {
-		extractors[node.left.type](names, node.left);
-	},
-
-	MemberExpression(names, node) {
-		extractors[node.property.type](names, node.property);
-	}
-};
-
 export function isTruthy(node) {
 	if (node.type === 'Literal') return !!node.value;
 	if (node.type === 'ParenthesizedExpression') return isTruthy(node.expression);

--- a/src/transform.js
+++ b/src/transform.js
@@ -1,7 +1,7 @@
 import { walk } from 'estree-walker';
 import MagicString from 'magic-string';
-import { attachScopes, makeLegalIdentifier } from 'rollup-pluginutils';
-import { extractNames, flatten, isFalsy, isReference, isTruthy } from './ast-utils.js';
+import { attachScopes, extractAssignedNames, makeLegalIdentifier } from 'rollup-pluginutils';
+import { flatten, isFalsy, isReference, isTruthy } from './ast-utils.js';
 import { HELPERS_ID, PROXY_PREFIX } from './helpers.js';
 import { getName } from './utils.js';
 
@@ -155,7 +155,7 @@ export function transformCommonjs(
 			if (node.type !== 'AssignmentExpression') return;
 			if (node.left.type === 'MemberExpression') return;
 
-			extractNames(node.left).forEach(name => {
+			extractAssignedNames(node.left).forEach(name => {
 				assignedTo.add(name);
 			});
 		}


### PR DESCRIPTION
Resolves #303

This switches to using the new shared helper for extracting names from patterns and should fix the last remaining pattern-related issue. For the future, there is now a central place for fixing these kinds of issues.