### PR TITLE
Normalize ids before looking up in named export map

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,13 +41,14 @@ export default function commonjs(options = {}) {
 				resolvedId = resolve(id);
 			}
 
-			// ASSERT: resolvedId is a normalized path
+			// Note: customNamedExport's keys must be normalized file paths.
+			// resolve and nodeResolveSync both return normalized file paths
+			// so no additional normalization is necessary.
 			customNamedExports[resolvedId] = options.namedExports[id];
 
 			if (existsSync(resolvedId)) {
 				const realpath = realpathSync(resolvedId);
 				if (realpath !== resolvedId) {
-					// ASSERT: realpath is a normalized path
 					customNamedExports[realpath] = options.namedExports[id];
 				}
 			}

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import { realpathSync, existsSync } from 'fs';
-import { extname, resolve } from 'path';
+import { extname, resolve, normalize } from 'path';
 import { sync as nodeResolveSync, isCore } from 'resolve';
 import { createFilter } from 'rollup-pluginutils';
 import { peerDependencies } from '../package.json';
@@ -40,11 +40,14 @@ export default function commonjs(options = {}) {
 			} catch (err) {
 				resolvedId = resolve(id);
 			}
+
+			// ASSERT: resolvedId is a normalized path
 			customNamedExports[resolvedId] = options.namedExports[id];
 
 			if (existsSync(resolvedId)) {
 				const realpath = realpathSync(resolvedId);
 				if (realpath !== resolvedId) {
+					// ASSERT: realpath is a normalized path
 					customNamedExports[realpath] = options.namedExports[id];
 				}
 			}
@@ -81,6 +84,8 @@ export default function commonjs(options = {}) {
 				return null;
 			}
 
+			const normalizedId = normalize(id);
+
 			const transformed = transformCommonjs(
 				this.parse,
 				code,
@@ -88,7 +93,7 @@ export default function commonjs(options = {}) {
 				this.getModuleInfo(id).isEntry,
 				ignoreGlobal,
 				ignoreRequire,
-				customNamedExports[id],
+				customNamedExports[normalizedId],
 				sourceMap,
 				allowDynamicRequire,
 				ast

--- a/test/test.js
+++ b/test/test.js
@@ -823,20 +823,18 @@ exports.shuffleArray = shuffleArray_1;
 			);
 		});
 
-		it.only('normalizes paths used in the named export map', async () => {
+		it('normalizes paths used in the named export map', async () => {
 			// Deliberately denormalizes file paths and ensures named exports
 			// continue to work.
 			function hookedResolve() {
 				const resolvePlugin = resolve();
 				const oldResolve = resolvePlugin.resolveId;
-				resolvePlugin.resolveId = async function(source) {
+				resolvePlugin.resolveId = async function() {
 					const result = await oldResolve.apply(resolvePlugin, arguments);
-					if (source === 'external') {
-						result.id = result.id.replace(/\\/g, '/');
-						return result;
-					} else if (source.match(/custom-named-exports/)) {
-						result.id = result.id.replace(/\//g, '\\');
+					if (result) {
+						result.id = result.id.replace(/\/|\\/, path.sep);
 					}
+
 					return result;
 				};
 

--- a/test/test.js
+++ b/test/test.js
@@ -822,5 +822,41 @@ exports.shuffleArray = shuffleArray_1;
 `
 			);
 		});
+
+		it.only('normalizes paths used in the named export map', async () => {
+			// Deliberately denormalizes file paths and ensures named exports
+			// continue to work.
+			function hookedResolve() {
+				const resolvePlugin = resolve();
+				const oldResolve = resolvePlugin.resolveId;
+				resolvePlugin.resolveId = async function(source) {
+					const result = await oldResolve.apply(resolvePlugin, arguments);
+					if (source === 'external') {
+						result.id = result.id.replace(/\\/g, '/');
+						return result;
+					} else if (source.match(/custom-named-exports/)) {
+						result.id = result.id.replace(/\//g, '\\');
+					}
+					return result;
+				};
+
+				return resolvePlugin;
+			}
+
+			const bundle = await rollup({
+				input: 'samples/custom-named-exports/main.js',
+				plugins: [
+					hookedResolve(),
+					commonjs({
+						namedExports: {
+							'samples/custom-named-exports/secret-named-exporter.js': ['named'],
+							external: ['message']
+						}
+					})
+				]
+			});
+
+			await executeBundle(bundle);
+		});
 	});
 });


### PR DESCRIPTION
This fixes an issue frequently hit when using the typescript rollup plugin. Because TypeScript always returns posix paths, but node resolve will normalize on a per-platform basis, comparisons must be carried out on normalized forms. This PR fixes some missing normalization and obviates rollup-plugin-typescript2's `rollupCommonJSResolveHack` option (/cc @ezolenko), and fixes #177 and probably a few others as well.