### PR TITLE
Emit error if mixing module syntax exist in same file

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ export default {
       ignoreGlobal: false,  // Default: false
 
       // if false then skip sourceMap generation for CommonJS modules
-      sourceMap: false,  // Default: true
+			sourceMap: false,  // Default: true
+			
+			// if true then emit error if CommonJS and ESM syntax exist in same file
+			noMixingModuleSyntax: true, // Default: false
 
       // explicitly specify unresolvable named exports
       // (see below for more details)

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ export default function commonjs(options = {}) {
 	const extensions = options.extensions || ['.js'];
 	const filter = createFilter(options.include, options.exclude);
 	const ignoreGlobal = options.ignoreGlobal;
+	const noMixingModuleSyntax = options.noMixingModuleSyntax;
 
 	const customNamedExports = {};
 	if (options.namedExports) {
@@ -73,6 +74,16 @@ export default function commonjs(options = {}) {
 	function transformAndCheckExports(code, id) {
 		{
 			const { isEsModule, hasDefaultExport, ast } = checkEsModule(this.parse, code, id);
+
+			// Throw error if ESM and CommonJS syntax both exist in same file
+			if (noMixingModuleSyntax) {
+				if (isEsModule && hasCjsKeywords(code, ignoreGlobal)) {
+					this.error(
+						`rollup-plugin-commonjs could not transform file includes CommonJS and ESM syntax at same time`
+					);
+				}
+			}
+
 			if (isEsModule) {
 				(hasDefaultExport ? esModulesWithDefaultExport : esModulesWithoutDefaultExport).add(id);
 				return null;

--- a/test/samples/cjs-and-esm/main.js
+++ b/test/samples/cjs-and-esm/main.js
@@ -1,0 +1,7 @@
+import 'foo'
+
+function f() {
+  require('bar')
+}
+
+f();

--- a/test/test.js
+++ b/test/test.js
@@ -670,6 +670,20 @@ describe('rollup-plugin-commonjs', () => {
 			}
 		});
 
+		it('emit an error if CommonJS and ESM syntax both exist', async () => {
+			try {
+				await rollup({
+					input: 'samples/cjs-and-esm/main.js',
+					plugins: [commonjs({ noMixingModuleSyntax: true })]
+				});
+			} catch (err) {
+				assert.equal(
+					err.message,
+					'rollup-plugin-commonjs could not transform file includes CommonJS and ESM syntax at same time'
+				);
+			}
+		});
+
 		it('ignores virtual modules', async () => {
 			const bundle = await rollup({
 				input: 'samples/ignore-virtual-modules/main.js',


### PR DESCRIPTION
When i bundle the modules in `iife` type, the plugin will skip transforming CommonJS syntax if current file has found ESM syntax.

I think that will be the better choice if the plugin provides the option for throwing error in such case.

The changes as follow:

- Check the ESM and CommonJS both if `option.noMixingModuleSyntax` is true

- Throw error message if ESM and CommonJS syntax exist in same file